### PR TITLE
move openstudio load

### DIFF
--- a/lib/openstudio-workflow.rb
+++ b/lib/openstudio-workflow.rb
@@ -32,14 +32,14 @@ rescue LoadError => e
   warn 'Could not load Facter. Will not be able to save the IP address to the log'.red
 end
 
-require 'openstudio'
-
-require 'openstudio/extended_runner'
 require 'openstudio/workflow/version'
 require 'openstudio/workflow/multi_delegator'
 require 'openstudio/workflow/run'
 require 'openstudio/workflow/jobs/lib/apply_measures'
 require 'openstudio/workflow/time_logger'
+
+require 'openstudio'
+require 'openstudio/extended_runner'
 
 ENV['OPENSTUDIO_WORKFLOW'] = 'true'
 


### PR DESCRIPTION
this fixes the issue with the non-deterministic failures of parsing JSON data. Really, we have absolutely no idea why, but this fixes the issue.

The suspected culprit could be:
* Workflow namespace conflict
* Loading OpenStudio library first, then loading Ruby library
* The long list of requires in the openstudio.rb file causing conflict
* Logging namespace conflict.
* Keyser Soze

Lesson learned -- make sure to only require openstudio when you need it and after you have required everything else that your application needs. Only then can you safely require openstudio to extend the classes/methods of interest.

@brianlball 
