### PR TITLE
Runner analysis json

### DIFF
--- a/lib/openstudio/extended_runner.rb
+++ b/lib/openstudio/extended_runner.rb
@@ -6,12 +6,17 @@ class ExtendedRunner < OpenStudio::Ruleset::OSRunner
   attr_reader :workflow_arguments
 
   # Add in @workflow_arguments
-  def initialize(multi_logger, analysis_hash, datapoint_hash)
+  def initialize(multi_logger, analysis_hash, datapoint_hash, output_attributes)
     @multi_logger = multi_logger
     @analysis = analysis_hash
     @datapoint = datapoint_hash
+    @results = output_attributes
     @workflow_arguments = nil
     super()
+  end
+
+  def past_results
+    return @results
   end
 
   def analysis

--- a/lib/openstudio/extended_runner.rb
+++ b/lib/openstudio/extended_runner.rb
@@ -6,10 +6,20 @@ class ExtendedRunner < OpenStudio::Ruleset::OSRunner
   attr_reader :workflow_arguments
 
   # Add in @workflow_arguments
-  def initialize(multi_logger)
+  def initialize(multi_logger, analysis_hash, datapoint_hash)
     @multi_logger = multi_logger
+    @analysis = analysis_hash
+    @datapoint = datapoint_hash
     @workflow_arguments = nil
     super()
+  end
+
+  def analysis
+    return @analysis
+  end
+
+  def datapoint
+    return @datapoint
   end
 
   # Take the OS Argument type and map it correctly to the argument value.

--- a/lib/openstudio/workflow/jobs/lib/apply_measures.rb
+++ b/lib/openstudio/workflow/jobs/lib/apply_measures.rb
@@ -126,7 +126,7 @@ module OpenStudio
           begin
             require measure_file_path
             measure = Object.const_get(measure_name).new
-            runner = ExtendedRunner.new(@logger, @anlaysis_json, @datapoint_json, @output_attributes)
+            runner = ExtendedRunner.new(@logger, @analysis_json, @datapoint_json, @output_attributes)
             runner.former_workflow_arguments = @workflow_arguments
           rescue => e
             log_message = "Error requiring measure #{__FILE__}. Failed with #{e.message}, #{e.backtrace.join("\n")}"

--- a/lib/openstudio/workflow/jobs/lib/apply_measures.rb
+++ b/lib/openstudio/workflow/jobs/lib/apply_measures.rb
@@ -126,7 +126,7 @@ module OpenStudio
           begin
             require measure_file_path
             measure = Object.const_get(measure_name).new
-            runner = ExtendedRunner.new(@logger, @anlaysis_json, @datapoint_json)
+            runner = ExtendedRunner.new(@logger, @anlaysis_json, @datapoint_json, @output_attributes)
             runner.former_workflow_arguments = @workflow_arguments
           rescue => e
             log_message = "Error requiring measure #{__FILE__}. Failed with #{e.message}, #{e.backtrace.join("\n")}"

--- a/lib/openstudio/workflow/jobs/lib/apply_measures.rb
+++ b/lib/openstudio/workflow/jobs/lib/apply_measures.rb
@@ -126,7 +126,7 @@ module OpenStudio
           begin
             require measure_file_path
             measure = Object.const_get(measure_name).new
-            runner = OpenStudio::Workflow::ExtendedRunner.new(@logger, @anlaysis_json, @datapoint_json)
+            runner = ExtendedRunner.new(@logger, @anlaysis_json, @datapoint_json)
             runner.former_workflow_arguments = @workflow_arguments
           rescue => e
             log_message = "Error requiring measure #{__FILE__}. Failed with #{e.message}, #{e.backtrace.join("\n")}"

--- a/lib/openstudio/workflow/jobs/lib/apply_measures.rb
+++ b/lib/openstudio/workflow/jobs/lib/apply_measures.rb
@@ -126,7 +126,7 @@ module OpenStudio
           begin
             require measure_file_path
             measure = Object.const_get(measure_name).new
-            runner = ExtendedRunner.new @logger
+            runner = OpenStudio::Workflow::ExtendedRunner.new(@logger, @anlaysis_json, @datapoint_json)
             runner.former_workflow_arguments = @workflow_arguments
           rescue => e
             log_message = "Error requiring measure #{__FILE__}. Failed with #{e.message}, #{e.backtrace.join("\n")}"


### PR DESCRIPTION
Adding runner.analysis and runner.datapoint capabilities to the extended runner object for DEnCity support. (More generally to allow measures to know what has been previously run, and what will be run in the future.)