### PR TITLE
Initial stab about output schema

### DIFF
--- a/spec/schema/osw_output.json
+++ b/spec/schema/osw_output.json
@@ -1,0 +1,262 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$ref": "#/definitions/OpenStudioWorkflow Schema",
+	"definitions": {
+		"Argument": {
+			"title": "argument",
+			"description": "Hash defining a single measure input",
+			"type": "object",
+			"properties": {
+				"name": {
+					"description": "Machine readable argument name as defined in the measure.xml",
+					"type": "string"
+				},
+				"value": {
+					"description": "Value that the argument is to be set to",
+					"type": [
+						"string",
+						"number",
+						"boolean"
+					]
+				}
+			},
+			"required": [
+				"name",
+				"value"
+			],
+			"additionalProperties": false
+		},
+		"Workflow Step Result": {
+			"description": "Result is populated when the workflow step is run.",
+			"type": "object",
+			"properties": {
+				"value": {
+					"description": "Overall result value of the measure.",
+					"type": "string",
+					"enum": [
+						"Success",
+						"Fail",
+						"NotApplicable"
+					]
+				},
+				"initial_condition": {
+					"description": "Condition of the model before the workflow step",
+					"type": "string"
+				},
+				"final_condition": {
+					"description": "Condition of the model after the workflow step",
+					"type": "string"
+				},
+				"errors": {
+					"description": "Any errors that ocurred during the workflow step.  Simulation workflow will halt if any errors are present.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"warnings": {
+					"description": "Any warnings that occurred during the workflow step.  Simulation workflow will not halt due to precense of warnings.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"info": {
+					"description": "Any info messages that occur during the workflow step.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"attributes": {
+					"description": "Named output attributes that are added using runner.registerValue",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/Output Attribute"
+					}
+				},
+				"files": {
+					"description": "New files that are generated during the worfklow step",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/Output File"
+					}
+				}
+			},
+			"additionalProperties": false
+		},
+		"Workflow Step": {
+			"description": "Hash defining an indivigual measure",
+			"type": "object",
+			"properties": {
+				"measure_dir_name": {
+					"description": "Measure directory name containing the measure.rb file",
+					"type": "string"
+				},
+				"arguments": {
+					"$ref": "#/definitions/Argument Array"
+				},
+				"result": {
+					"$ref": "#/definitions/Workflow Step Result"
+				}
+			},
+			"required": [
+				"measure_dir_name",
+				"arguments"
+			],
+			"additionalProperties": false
+		},
+		"Workflow Steps": {
+			"description": "Array of measures to be executed in the simulation process",
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/Workflow Step"
+			}
+		},
+		"Seed Definition": {
+			"title": "seed_file",
+			"description": "String defining the filepath for the seed model relative to the osw file",
+			"type": "string"
+		},
+		"Weather Definition": {
+			"title": "weather_file",
+			"description": "String defining the filepath for the weather file relative to the osw instance",
+			"type": "string"
+		},
+		"OpenStudioWorkflow Schema": {
+			"description": "JSON Schema for the OpenStudioWorkflow (OSW) file format",
+			"type": "object",
+			"properties": {
+				"weather_file": {
+					"$ref": "#/definitions/Weather Definition"
+				},
+				"seed_file": {
+					"$ref": "#/definitions/Seed Definition"
+				},
+				"steps": {
+					"$ref": "#/definitions/Workflow Steps"
+				},
+				"energyplus_result": {
+					"$ref": "#/definitions/Workflow Step Result"
+				},
+				"file_format_version": {
+					"description": "Currently 0.1, however will infered to be the default of the software package unless otherwise specified",
+					"type": "number"
+				},
+				"osa_id": {
+					"description": "UUID of the .osa file fron which this file was generated, or null if not generated from a .osa file",
+					"type": [
+						"string",
+						"null"
+					]
+				},
+				"osa_checksum": {
+					"description": "Checksum of the .osa file from which this file was generated, or null if not generated from a .osa file",
+					"type": [
+						"number",
+						"null"
+					]
+				},
+				"osd_id": {
+					"description": "UUID of the .osd file from which this file was generated, or null if not generated from a .osd file",
+					"type": [
+						"string",
+						"null"
+					]
+				},
+				"osd_checksum": {
+					"description": "Checksum of the .osd file from which this file was generated, or null if not generated from a .osd file",
+					"type": [
+						"number",
+						"null"
+					]
+				},
+				"created_at": {
+					"$ref": "#/definitions/Timestamp"
+				},
+				"updated_at": {
+					"$ref": "#/definitions/Timestamp"
+				},
+				"completed_at": {
+					"$ref": "#/definitions/Timestamp"
+				},
+				"completed_status": {
+					"type": "string",
+					"enum": [
+						"Success",
+						"Fail"
+					]
+				},
+				"id": {
+					"description": "UUID of this file",
+					"type": "string"
+				},
+				"root": {
+					"description": "Path to the root directory against which relative paths are evaluated.  If root is empty, the directory containing the osw is used.",
+					"type": "string"
+				},
+				"run_directory": {
+					"description": "Path to the run directory: note that a run folder will be created in the target location",
+					"type": "string"
+				},
+				"file_paths": {
+					"description": "A set of ordered directories relative to root_directory to search for required files and libraries",
+					"type": "array",
+					"items": {
+						"description": "A path relative to the root_dir which should be searched for support files and folders",
+						"type": "string"
+					}
+				},
+				"measure_paths": {
+					"description": "A set of ordered directories relative to root_directory to search for required measures",
+					"type": "array",
+					"items": {
+						"description": "A path relative to the root_directory which should be searched for support files and folders",
+						"type": "string"
+					}
+				}
+			},
+			"required": [
+				"steps"
+			],
+			"additionalProperties": false
+		},
+		"Argument Array": {
+			"description": "Array defining inputs to the measure",
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/Argument"
+			}
+		},
+		"Output Attribute": {
+			"type": "object",
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"value": {}
+			},
+			"required": [
+				"name",
+				"value"
+			],
+			"additionalProperties": false
+		},
+		"Output File": {
+			"type": "object",
+			"properties": {
+				"path": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"path"
+			],
+			"additionalProperties": false
+		},
+		"Timestamp": {
+			"description": "ISO8601 string defining a fully qualified date time",
+			"type": "string"
+		}
+	}
+}

--- a/spec/schema/osw_output.json
+++ b/spec/schema/osw_output.json
@@ -30,6 +30,12 @@
 			"description": "Result is populated when the workflow step is run.",
 			"type": "object",
 			"properties": {
+				"started_at": {
+					"$ref": "#/definitions/Timestamp"
+				},
+				"completed_at": {
+					"$ref": "#/definitions/Timestamp"
+				},
 				"value": {
 					"description": "Overall result value of the measure.",
 					"type": "string",
@@ -81,7 +87,25 @@
 					"items": {
 						"$ref": "#/definitions/Output File"
 					}
+				},
+				"stdout": {
+					"description": "Output written to standard out during workflow step.",
+					"type": "string"
+				},
+				"stderr": {
+					"description": "Output written to standard error during workflow step.",
+					"type": "string"
 				}
+			},
+			"dependencies": {
+				"completed_at": [
+					"value",
+					"errors",
+					"warnings",
+					"info",
+					"attributes",
+					"files"
+				]
 			},
 			"additionalProperties": false
 		},
@@ -136,6 +160,9 @@
 				"steps": {
 					"$ref": "#/definitions/Workflow Steps"
 				},
+				"energplus_translator_result": {
+					"$ref": "#/definitions/Workflow Step Result"
+				},
 				"energyplus_result": {
 					"$ref": "#/definitions/Workflow Step Result"
 				},
@@ -173,6 +200,13 @@
 				},
 				"created_at": {
 					"$ref": "#/definitions/Timestamp"
+				},
+				"started_at": {
+					"$ref": "#/definitions/Timestamp"
+				},
+				"current_step": {
+					"description": "Index of current workflow step, first step is index 0.  If running EnergyPlus, current step refers to last step before EnergyPlus.",
+					"type": "number"
 				},
 				"updated_at": {
 					"$ref": "#/definitions/Timestamp"
@@ -219,6 +253,15 @@
 			"required": [
 				"steps"
 			],
+			"dependencies": {
+				"completed_at": [
+					"completed_status"
+				],
+				"started_at": [
+					"current_step",
+					"updated_at"
+				]
+			},
 			"additionalProperties": false
 		},
 		"Argument Array": {

--- a/spec/schema/osw_output.json
+++ b/spec/schema/osw_output.json
@@ -109,8 +109,8 @@
 			},
 			"additionalProperties": false
 		},
-		"Workflow Step": {
-			"description": "Hash defining an indivigual measure",
+		"Measure Step": {
+			"description": "This step runs a measure with given arguments.  The measure can either be a Model, EnergyPlus, or Reporting Model.",
 			"type": "object",
 			"properties": {
 				"measure_dir_name": {
@@ -130,27 +130,140 @@
 			],
 			"additionalProperties": false
 		},
+		"ModelToIdf Step": {
+			"description": "This step converts the Model to EnergyPlus IDF",
+			"type": "object",
+			"properties": {
+				"model_to_idf": {
+					"type": "boolean",
+					"enum": [
+						true
+					],
+					"default": true
+				},
+				"result": {
+					"$ref": "#/definitions/Workflow Step Result"
+				}
+			},
+			"required": [
+				"model_to_idf"
+			],
+			"additionalProperties": false
+		},
+		"EnergyPlus Step": {
+			"description": "This step runs EnergyPlus as well as ExpandObjects and preprocessing the IDF.",
+			"type": "object",
+			"properties": {
+				"expand_objects": {
+					"type": "boolean",
+					"default": true
+				},
+				"energyplus_preprocess": {
+					"type": "boolean",
+					"default": true
+				},
+				"energyplus": {
+					"type": "boolean",
+					"default": true
+				},
+				"result": {
+					"$ref": "#/definitions/Workflow Step Result"
+				}
+			},
+			"required": [
+				"energyplus"
+			],
+			"additionalProperties": false
+		},
+		"Post Process Step": {
+			"description": "This step deletes temporary files and copies results to a known location.  Omitting this step is equivalent to setting post_process equal to none.",
+			"type": "object",
+			"properties": {
+				"post_process": {
+					"type": "string",
+					"enum": [
+						"None",
+						"Normal",
+						"Maximum"
+					]
+				},
+				"result": {
+					"$ref": "#/definitions/Workflow Step Result"
+				}
+			},
+			"required": [
+				"post_process"
+			],
+			"additionalProperties": false
+		},
 		"Workflow Steps": {
 			"description": "Array of measures to be executed in the simulation process",
 			"type": "array",
 			"items": {
-				"$ref": "#/definitions/Workflow Step"
+				"type": "object",
+				"additionalProperties": false,
+				"oneOf": [
+					{
+						"$ref": "#/definitions/Measure Step"
+					},
+					{
+						"$ref": "#/definitions/ModelToIdf Step"
+					},
+					{
+						"$ref": "#/definitions/EnergyPlus Step"
+					},
+					{
+						"$ref": "#/definitions/Post Process Step"
+					}
+				]
 			}
 		},
 		"Seed Definition": {
 			"title": "seed_file",
-			"description": "String defining the filepath for the seed model relative to the osw file",
+			"description": "String defining the filename for the seed model in the file_paths",
 			"type": "string"
 		},
 		"Weather Definition": {
 			"title": "weather_file",
-			"description": "String defining the filepath for the weather file relative to the osw instance",
+			"description": "String defining the filename for the weather file in the file_paths",
 			"type": "string"
 		},
 		"OpenStudioWorkflow Schema": {
 			"description": "JSON Schema for the OpenStudioWorkflow (OSW) file format",
 			"type": "object",
 			"properties": {
+				"file_format_version": {
+					"description": "Currently 0.1, however will infered to be the default of the software package unless otherwise specified",
+					"type": "number"
+				},
+				"id": {
+					"description": "UUID of this file",
+					"type": "string"
+				},
+				"root": {
+					"description": "Path to the root directory against which relative paths are evaluated.  If root is empty, the directory containing the osw is used.",
+					"type": "string"
+				},
+				"run_directory": {
+					"description": "Path to the run directory relative to root directory: note that a run folder will be created in the target location",
+					"type": "string"
+				},
+				"file_paths": {
+					"description": "A set of ordered directories relative to root_directory to search for required files and libraries",
+					"type": "array",
+					"items": {
+						"description": "A path relative to the root_dir which should be searched for support files and folders",
+						"type": "string"
+					}
+				},
+				"measure_paths": {
+					"description": "A set of ordered directories relative to root_directory to search for required measures",
+					"type": "array",
+					"items": {
+						"description": "A path relative to the root_directory which should be searched for support files and folders",
+						"type": "string"
+					}
+				},
 				"weather_file": {
 					"$ref": "#/definitions/Weather Definition"
 				},
@@ -159,16 +272,6 @@
 				},
 				"steps": {
 					"$ref": "#/definitions/Workflow Steps"
-				},
-				"energplus_translator_result": {
-					"$ref": "#/definitions/Workflow Step Result"
-				},
-				"energyplus_result": {
-					"$ref": "#/definitions/Workflow Step Result"
-				},
-				"file_format_version": {
-					"description": "Currently 0.1, however will infered to be the default of the software package unless otherwise specified",
-					"type": "number"
 				},
 				"osa_id": {
 					"description": "UUID of the .osa file fron which this file was generated, or null if not generated from a .osa file",
@@ -205,7 +308,7 @@
 					"$ref": "#/definitions/Timestamp"
 				},
 				"current_step": {
-					"description": "Index of current workflow step, first step is index 0.  If running EnergyPlus, current step refers to last step before EnergyPlus.",
+					"description": "Index of current workflow step, first step is index 0. Index remains at the last running step if error occurs.",
 					"type": "number"
 				},
 				"updated_at": {
@@ -215,39 +318,12 @@
 					"$ref": "#/definitions/Timestamp"
 				},
 				"completed_status": {
+					"description": "If the workflow is complete records if it failed or succeeded.",
 					"type": "string",
 					"enum": [
 						"Success",
 						"Fail"
 					]
-				},
-				"id": {
-					"description": "UUID of this file",
-					"type": "string"
-				},
-				"root": {
-					"description": "Path to the root directory against which relative paths are evaluated.  If root is empty, the directory containing the osw is used.",
-					"type": "string"
-				},
-				"run_directory": {
-					"description": "Path to the run directory: note that a run folder will be created in the target location",
-					"type": "string"
-				},
-				"file_paths": {
-					"description": "A set of ordered directories relative to root_directory to search for required files and libraries",
-					"type": "array",
-					"items": {
-						"description": "A path relative to the root_dir which should be searched for support files and folders",
-						"type": "string"
-					}
-				},
-				"measure_paths": {
-					"description": "A set of ordered directories relative to root_directory to search for required measures",
-					"type": "array",
-					"items": {
-						"description": "A path relative to the root_directory which should be searched for support files and folders",
-						"type": "string"
-					}
 				}
 			},
 			"required": [


### PR DESCRIPTION
Creating a pull request for discussion.  This adds various output results to the OSW schema.  Few things to discuss:

- Should the output OSW overwrite the input OSW as it is generated (I vote no)?  If not, what convention is used to generate the output OSW (in.osw -> in.osw.out)?
- Having explicit steps for EnergyPlus, and ForwardTranslator would allow a nice place to stick results for those jobs and would make indicating the current job using current_step index easier
- Can this output be mapped back to OSD format easily?  Objective functions are not specified in this format, something else has to go get the attributes from the correct steps.  Is that possible?
