### PR TITLE
Fast option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ in.idf
 run.log
 reports
 */**/out.osw
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,6 @@ source 'http://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rake'
-  gem 'json-schema', '~> 2.6'
   gem 'coveralls', require: false
-  gem 'ruby-prof', '0.15.8'
-  gem 'rspec', '~> 3.3'
-  gem 'ci_reporter_rspec'
-  gem 'rubocop'
-  gem 'rubocop-checkstyle_formatter'
-  gem 'parallel' # for DencityReports measure
+
 end

--- a/lib/openstudio/workflow/adapters/input/local.rb
+++ b/lib/openstudio/workflow/adapters/input/local.rb
@@ -172,6 +172,19 @@ module OpenStudio
           return default
         end
         
+        def skip_expand_objects(user_options, default)
+          
+          # user option trumps all others
+          return user_options[:skip_expand_objects] if user_options[:skip_expand_objects]
+          
+          # try to read from OSW
+          if @run_options && !@run_options.empty?
+            return @run_options.get.skipExpandObjects
+          end
+        
+          return default
+        end
+        
         def cleanup(user_options, default)
           
           # user option trumps all others

--- a/lib/openstudio/workflow/adapters/input/local.rb
+++ b/lib/openstudio/workflow/adapters/input/local.rb
@@ -185,6 +185,19 @@ module OpenStudio
           return default
         end
         
+        def skip_energyplus_preprocess(user_options, default)
+          
+          # user option trumps all others
+          return user_options[:skip_energyplus_preprocess] if user_options[:skip_energyplus_preprocess]
+          
+          # try to read from OSW
+          if @run_options && !@run_options.empty?
+            return @run_options.get.skipEnergyPlusPreprocess
+          end
+        
+          return default
+        end
+        
         def cleanup(user_options, default)
           
           # user option trumps all others

--- a/lib/openstudio/workflow/adapters/input/local.rb
+++ b/lib/openstudio/workflow/adapters/input/local.rb
@@ -151,6 +151,14 @@ module OpenStudio
           return default
         end
         
+        def fast(user_options, default)
+        
+          # user option trumps all others
+          return user_options[:fast] if user_options[:fast]
+        
+          return default
+        end
+        
         def preserve_run_dir(user_options, default)
           
           # user option trumps all others

--- a/lib/openstudio/workflow/jobs/run_os_measures.rb
+++ b/lib/openstudio/workflow/jobs/run_os_measures.rb
@@ -57,7 +57,9 @@ class RunOpenStudioMeasures < OpenStudio::Workflow::Job
     @output_adapter.communicate_measure_attributes @registry[:output_attributes]
 
     # save the final OSM
-    save_osm(@registry[:model], @registry[:run_dir])
+    if !@options[:fast]
+      save_osm(@registry[:model], @registry[:run_dir])
+    end
 
     # Save the OSM if the :debug option is true
     return nil unless @options[:debug]

--- a/lib/openstudio/workflow/jobs/run_postprocess.rb
+++ b/lib/openstudio/workflow/jobs/run_postprocess.rb
@@ -36,9 +36,11 @@ class RunPostprocess < OpenStudio::Workflow::Job
 
     # do not skip post_process if halted
     
-    @logger.info 'Gathering reports'
-    gather_reports(@registry[:run_dir], @registry[:root_dir], @registry[:workflow_json], @logger)
-    @logger.info 'Finished gathering reports'
+    if !@options[:fast]
+      @logger.info 'Gathering reports'
+      gather_reports(@registry[:run_dir], @registry[:root_dir], @registry[:workflow_json], @logger)
+      @logger.info 'Finished gathering reports'
+    end
 
     if @options[:cleanup]
       @logger.info 'Beginning cleanup of the run directory'

--- a/lib/openstudio/workflow/jobs/run_preprocess.rb
+++ b/lib/openstudio/workflow/jobs/run_preprocess.rb
@@ -37,7 +37,7 @@ class RunPreprocess < OpenStudio::Workflow::Job
     FileUtils.mkdir_p(@registry[:run_dir])
 
     # save the pre-preprocess file
-    if !@options[:fast]
+    if !@options[:skip_energyplus_preprocess]
       File.open("#{@registry[:run_dir]}/pre-preprocess.idf", 'w') { |f| f << @registry[:model_idf].to_s }
     end
 
@@ -53,7 +53,7 @@ class RunPreprocess < OpenStudio::Workflow::Job
     return nil if halted
 
     # Perform pre-processing on in.idf to capture logic in RunManager
-    if !@options[:fast]
+    if !@options[:skip_energyplus_preprocess]
       @registry[:time_logger].start('Running EnergyPlus Preprocess') if @registry[:time_logger]
       energyplus_preprocess(@registry[:model_idf], @logger)
       @registry[:time_logger].start('Running EnergyPlus Preprocess') if @registry[:time_logger]

--- a/lib/openstudio/workflow/jobs/run_preprocess.rb
+++ b/lib/openstudio/workflow/jobs/run_preprocess.rb
@@ -37,7 +37,9 @@ class RunPreprocess < OpenStudio::Workflow::Job
     FileUtils.mkdir_p(@registry[:run_dir])
 
     # save the pre-preprocess file
-    File.open("#{@registry[:run_dir]}/pre-preprocess.idf", 'w') { |f| f << @registry[:model_idf].to_s }
+    if !@options[:fast]
+      File.open("#{@registry[:run_dir]}/pre-preprocess.idf", 'w') { |f| f << @registry[:model_idf].to_s }
+    end
 
     # Add any EnergyPlus Output Requests from Reporting Measures
     @logger.info 'Beginning to collect output requests from Reporting measures.'
@@ -51,10 +53,12 @@ class RunPreprocess < OpenStudio::Workflow::Job
     return nil if halted
 
     # Perform pre-processing on in.idf to capture logic in RunManager
-    @registry[:time_logger].start('Running EnergyPlus Preprocess') if @registry[:time_logger]
-    energyplus_preprocess(@registry[:model_idf], @logger)
-    @registry[:time_logger].start('Running EnergyPlus Preprocess') if @registry[:time_logger]
-    @logger.info 'Finished preprocess job for EnergyPlus simulation'
+    if !@options[:fast]
+      @registry[:time_logger].start('Running EnergyPlus Preprocess') if @registry[:time_logger]
+      energyplus_preprocess(@registry[:model_idf], @logger)
+      @registry[:time_logger].start('Running EnergyPlus Preprocess') if @registry[:time_logger]
+      @logger.info 'Finished preprocess job for EnergyPlus simulation'
+    end
 
     # Save the model objects in the registry to the run directory
     if File.exist?("#{@registry[:run_dir]}/in.idf")

--- a/lib/openstudio/workflow/run.rb
+++ b/lib/openstudio/workflow/run.rb
@@ -76,6 +76,7 @@ module OpenStudio
       # @option user_options [Hash] :output_adapter Output adapter to use, overrides output adapter in OSW if set, defaults to local adapter
       # @option user_options [Hash] :preserve_run_dir Prevents run directory from being cleaned prior to run, overrides OSW option if set, defaults to false - DLM, Deprecate
       # @option user_options [Hash] :profile Produce additional output for profiling simulations, defaults to false
+      # @option user_options [Hash] :skip_expand_objects Skips the call to the EnergyPlus ExpandObjects program
       # @option user_options [Hash] :targets Log targets to write to, defaults to standard out and run.log
       # @option user_options [Hash] :verify_osw Check OSW for correctness, defaults to true
       # @option user_options [Hash] :weather_file Initial weather file to load, overrides OSW option if set, defaults to empty
@@ -127,6 +128,7 @@ module OpenStudio
         # get info to set up logging first in case of failures later
         @options[:debug] = @input_adapter.debug(user_options, false)
         @options[:preserve_run_dir] = @input_adapter.preserve_run_dir(user_options, false)
+        @options[:skip_expand_objects] = @input_adapter.skip_expand_objects(user_options, false)
         @options[:profile] = @input_adapter.profile(user_options, false)
         
         # if running in osw dir, force preserve run dir

--- a/lib/openstudio/workflow/run.rb
+++ b/lib/openstudio/workflow/run.rb
@@ -76,6 +76,7 @@ module OpenStudio
       # @option user_options [Hash] :output_adapter Output adapter to use, overrides output adapter in OSW if set, defaults to local adapter
       # @option user_options [Hash] :preserve_run_dir Prevents run directory from being cleaned prior to run, overrides OSW option if set, defaults to false - DLM, Deprecate
       # @option user_options [Hash] :profile Produce additional output for profiling simulations, defaults to false
+      # @option user_options [Hash] :skip_energyplus_preprocess Skips handling of reporting variables
       # @option user_options [Hash] :skip_expand_objects Skips the call to the EnergyPlus ExpandObjects program
       # @option user_options [Hash] :targets Log targets to write to, defaults to standard out and run.log
       # @option user_options [Hash] :verify_osw Check OSW for correctness, defaults to true
@@ -129,6 +130,7 @@ module OpenStudio
         @options[:debug] = @input_adapter.debug(user_options, false)
         @options[:preserve_run_dir] = @input_adapter.preserve_run_dir(user_options, false)
         @options[:skip_expand_objects] = @input_adapter.skip_expand_objects(user_options, false)
+        @options[:skip_energyplus_preprocess] = @input_adapter.skip_energyplus_preprocess(user_options, false)
         @options[:profile] = @input_adapter.profile(user_options, false)
         
         # if running in osw dir, force preserve run dir

--- a/lib/openstudio/workflow/run.rb
+++ b/lib/openstudio/workflow/run.rb
@@ -208,7 +208,7 @@ module OpenStudio
         begin
           next_state
           while @current_state != :finished && @current_state != :errored
-            #sleep 2
+            sleep 2
             step
           end
 

--- a/lib/openstudio/workflow/util/energyplus.rb
+++ b/lib/openstudio/workflow/util/energyplus.rb
@@ -97,20 +97,22 @@ module OpenStudio
           Dir.chdir(run_directory)
           logger.info "Starting simulation in run directory: #{Dir.pwd}"
 
-          command = popen_command("\"#{expand_objects_exe}\"")
-          logger.info "Running command '#{command}'"
-          File.open('stdout-expandobject', 'w') do |file|
-            ::IO.popen(command) do |io|
-              while (line = io.gets)
-                file << line
+          if !@options[:fast]
+            command = popen_command("\"#{expand_objects_exe}\"")
+            logger.info "Running command '#{command}'"
+            File.open('stdout-expandobject', 'w') do |file|
+              ::IO.popen(command) do |io|
+                while (line = io.gets)
+                  file << line
+                end
               end
             end
-          end
-
-          # Check if expand objects did anything
-          if File.exist? 'expanded.idf'
-            FileUtils.mv('in.idf', 'pre-expand.idf', force: true) if File.exist?('in.idf')
-            FileUtils.mv('expanded.idf', 'in.idf', force: true)
+          
+            # Check if expand objects did anything
+            if File.exist? 'expanded.idf'
+              FileUtils.mv('in.idf', 'pre-expand.idf', force: true) if File.exist?('in.idf')
+              FileUtils.mv('expanded.idf', 'in.idf', force: true)
+            end
           end
 
           # create stdout
@@ -136,7 +138,9 @@ module OpenStudio
             
             if workflow_json
               begin
-                workflow_json.setEplusoutErr(eplus_err)
+                if !@options[:fast]
+                  workflow_json.setEplusoutErr(eplus_err)
+                end
               rescue => e
                 # older versions of OpenStudio did not have the setEplusoutErr method
               end

--- a/lib/openstudio/workflow/util/energyplus.rb
+++ b/lib/openstudio/workflow/util/energyplus.rb
@@ -97,7 +97,7 @@ module OpenStudio
           Dir.chdir(run_directory)
           logger.info "Starting simulation in run directory: #{Dir.pwd}"
 
-          if !@options[:fast]
+          if !@options[:skip_expand_objects]
             command = popen_command("\"#{expand_objects_exe}\"")
             logger.info "Running command '#{command}'"
             File.open('stdout-expandobject', 'w') do |file|

--- a/openstudio-workflow.gemspec
+++ b/openstudio-workflow.gemspec
@@ -20,5 +20,17 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_development_dependency 'bundler', '~> 1.6'
-  s.add_development_dependency 'json-schema', '~> 0'
+  s.add_development_dependency 'json-schema', '2.8.0'
+  s.add_development_dependency 'rubocop-checkstyle_formatter', '0.4.0'
+  s.add_development_dependency 'ci_reporter', '2.0.0'
+  s.add_development_dependency 'ci_reporter_rspec', '1.0.0'
+  s.add_development_dependency 'builder', '2.1.2'
+  s.add_development_dependency 'rspec', '3.7.0'
+  s.add_development_dependency 'coveralls', '0.8.21'
+  s.add_development_dependency 'parallel', '1.12.1'
+
+  # Use an older versions of the items below as they requireRuby 2.1+
+  s.add_development_dependency 'rubocop', '0.49.1'
+  s.add_development_dependency 'public_suffix', '2.0.5'
+  s.add_development_dependency 'rainbow', '2.2.2'
 end

--- a/spec/schema/osw.json
+++ b/spec/schema/osw.json
@@ -86,6 +86,9 @@
 						"skip_expand_objects": {
 							"type": "boolean"
 						},
+						"skip_energyplus_preprocess": {
+							"type": "boolean"
+						},
 						"cleanup": {
 							"type": "boolean"
 						},

--- a/spec/schema/osw.json
+++ b/spec/schema/osw.json
@@ -83,6 +83,9 @@
 						"preserve_run_dir": {
 							"type": "boolean"
 						},
+						"skip_expand_objects": {
+							"type": "boolean"
+						},
 						"cleanup": {
 							"type": "boolean"
 						},

--- a/test/bin/docker-run.sh
+++ b/test/bin/docker-run.sh
@@ -2,8 +2,14 @@
 
 export CI=true
 export CIRCLECI=true
-export PATH="$HOME/.rbenv/bin:$PATH"
-eval "$(rbenv init -)"
+
+# Source rbenv if exists
+if which rbenv > /dev/null
+then
+    echo "rbenv installed... initializing"
+    export PATH="$HOME/.rbenv/bin:$PATH"
+    eval "$(rbenv init -)"
+fi
 
 # install dependencies and run default rake task
 cd /var/simdata/openstudio

--- a/test/bin/run_tests.sh
+++ b/test/bin/run_tests.sh
@@ -16,8 +16,7 @@ function run_docker {
   docker pull nrel/openstudio:$image
   docker run -e "COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN" \
       -v $(pwd):/var/simdata/openstudio nrel/openstudio:$image \
-      /var/simdata/openstudio/test/bin/docker-run.sh \
-      > ~/reports/rspec/$image/rpec_results.html
+      /var/simdata/openstudio/test/bin/docker-run.sh 2>&1 | tee ~/reports/rspec/$image/rpec_results.html
 }
 
 


### PR DESCRIPTION
Adds a `fast` option to turn off certain workflow steps in order to speed up residential simulations. Can be used in conjunction with the CLI by passing the `--fast` hidden argument (see https://github.com/NREL/OpenStudio/pull/3092).