### PR TITLE
Improve speed (REXML)

### DIFF
--- a/lib/openstudio/workflow/util/post_process.rb
+++ b/lib/openstudio/workflow/util/post_process.rb
@@ -38,7 +38,6 @@ module OpenStudio
     module Util
       require 'openstudio/workflow/util/measure'
       require 'csv'
-      require 'rexml/document'
 
       # This module serves as a wrapper around various post-processing tasks used to manage outputs
       # @todo (rhorsey) ummmm. So some of this is pretty ugly. Since @dmacumber had ideas about this maybe he can figure
@@ -193,6 +192,7 @@ module OpenStudio
                                                             measure_dir_name, 'measure.xml'))
             logger.info "measure_xml_path: #{measure_xml_path}"
             if File.exists? measure_xml_path
+              require 'rexml/document'
               measure_xml = REXML::Document.new File.read(measure_xml_path)
               measure_class_name = OpenStudio.toUnderscoreCase(measure_xml.root.elements['class_name'].text)
             else

--- a/lib/openstudio/workflow/util/post_process.rb
+++ b/lib/openstudio/workflow/util/post_process.rb
@@ -192,6 +192,7 @@ module OpenStudio
                                                             measure_dir_name, 'measure.xml'))
             logger.info "measure_xml_path: #{measure_xml_path}"
             if File.exists? measure_xml_path
+              # REXML is slow, so we lazy load only as needed
               require 'rexml/document'
               measure_xml = REXML::Document.new File.read(measure_xml_path)
               measure_class_name = OpenStudio.toUnderscoreCase(measure_xml.root.elements['class_name'].text)


### PR DESCRIPTION
Currently `require 'rexml/document'` is called during invocation; it takes ~0.75 seconds on Windows and ~0.5 seconds on Linux. But REXML is only used in one very specific situation when there are report files. Therefore, we can move the require statement into the report code block and lazy load REXML.