### PR TITLE
Python measure: modifications & Pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ reports
 */**/out*.osw
 .ruby-version
 IdfFilesToTransition.lst
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]

--- a/lib/openstudio/workflow/util/measure.rb
+++ b/lib/openstudio/workflow/util/measure.rb
@@ -359,10 +359,12 @@ module OpenStudio
               logger.debug "import sys"
               sys = PyCall.import_module('sys')
               logger.debug "sys.path: #{print sys.path}"
+              logger.debug sys.path
               python_include_path = "#{File.dirname(__FILE__)}/../../../../spec/files/python_measure/measures/PythonMeasure/"
               logger.debug "python_include_path: #{python_include_path}"
               sys.path.insert(0, "#{python_include_path}")
               logger.debug "sys.path: #{print sys.path}"
+              logger.debug sys.path
               #pyfrom 'measure', import: 'PythonMeasureName'
               logger.debug "pyimport measure"
               pyimport 'measure', as: 'measuremodule'
@@ -410,11 +412,13 @@ module OpenStudio
               if measure_type == 'PythonMeasure'.to_MeasureType
                 # We're getting a python map... so we need to convert that to a
                 # ruby one
+                # openstudio.openstudiomeasure.OSArgumentVector
                 puts("arguments.__class__: #{arguments.__class__}")
                 for i in 0..(arguments.__len__() - 1)
                   python_arg = arguments.__getitem__(i)
                   ruby_arg_type = OpenStudio::Measure::OSArgumentType.new(python_arg.type().value())
                   argument_map[python_arg.name()] = OpenStudio::Measure::OSArgument.new(python_arg.name(), ruby_arg_type, python_arg.required(), python_arg.modelDependent())
+                  logger.debug "arg #{python_arg.name()}"
                 end
               else
                 if arguments
@@ -555,6 +559,8 @@ module OpenStudio
                   logger.debug "Calling measure.run for '#{measure_dir_name}'"
                   if measure_type == 'ModelMeasure'.to_MeasureType
                     measure_object.run(@model, runner, argument_map)
+                  elsif measure_type == 'PythonMeasure'.to_MeasureType
+                    measure_object.run(@model, runner, argument_map)
                   elsif measure_type == 'EnergyPlusMeasure'.to_MeasureType
                     measure_object.run(@model_idf, runner, argument_map)
                   elsif measure_type == 'ReportingMeasure'.to_MeasureType
@@ -593,8 +599,9 @@ module OpenStudio
 
               result = nil
               begin
-                result = runner.result
-
+                result = runner.result()
+                puts "result"
+                puts result
                 # incrementStep must be called after run
                 runner.incrementStep
 

--- a/spec/files/python_measure/measures/PythonMeasure/measure.py
+++ b/spec/files/python_measure/measures/PythonMeasure/measure.py
@@ -43,10 +43,12 @@ class PythonMeasureName(openstudio.measure.PythonMeasure):
         """
         define what happens when the measure is run
         """
+        print("Hello!")
         super().run(model, runner, user_arguments)
-
-        if not(runner.validateUserArguments(self.arguments(model), user_arguments)):
+        if not(runner.validateUserArguments(self.arguments(model),
+                                            user_arguments)):
             return False
+
 
         # assign the user inputs to variables
         space_name = runner.getStringArgumentValue('space_name',
@@ -58,8 +60,10 @@ class PythonMeasureName(openstudio.measure.PythonMeasure):
             return False
 
         # report initial condition of model
+        n_ori = len(model.getSpaces())
+        print(f"The building started with {n_ori} spaces.")
         runner.registerInitialCondition(
-            f"The building started with {len(model.getSpaces())} spaces."
+            f"The building started with {n_ori} spaces."
         )
 
         # add a new space to the model

--- a/spec/files/python_measure/measures/PythonMeasure/measure.py
+++ b/spec/files/python_measure/measures/PythonMeasure/measure.py
@@ -1,5 +1,5 @@
 import openstudio
-
+import typing
 
 class PythonMeasureName(openstudio.measure.PythonMeasure):
 
@@ -22,7 +22,7 @@ class PythonMeasureName(openstudio.measure.PythonMeasure):
         """
         return "MODELER_DESCRIPTION_TEXT"
 
-    def arguments(self, model: openstudio.model.Model):
+    def arguments(self, model: typing.Optional[openstudio.model.Model]=None):
         """
         define what happens when the measure is run
         """

--- a/spec/files/python_measure/measures/PythonMeasure/tests/test_model_measure.py
+++ b/spec/files/python_measure/measures/PythonMeasure/tests/test_model_measure.py
@@ -5,80 +5,104 @@ import openstudio
 import pathlib
 from measure import PythonMeasureName
 
+
 class TestPythonMeasureName:
-  # def setup
-  # end
 
-  # def teardown
-  # end
+    def test_number_of_arguments_and_argument_names(self):
+        """
+        Test that the arguments are what we expect
+        """
+        # create an instance of the measure
+        measure = PythonMeasureName()
 
-  def test_number_of_arguments_and_argument_names(self):
-    # create an instance of the measure
-    measure = PythonMeasureName()
+        # make an empty model
+        model = openstudio.model.Model()
 
-    # make an empty model
-    model = openstudio.model.Model()
+        # get arguments and test that they are what we are expecting
+        arguments = measure.arguments(model)
+        assert arguments.size() == 1
+        assert arguments[0].name() == 'space_name'
 
-    # get arguments and test that they are what we are expecting
-    arguments = measure.arguments(model)
-    assert arguments.size() == 1
-    assert arguments[0].name() == 'space_name'
+    def test_optional_model_for_arguments(self):
+        """
+        Tests that passing model to arguments() is optional
+        """
+        # create an instance of the measure
+        measure = PythonMeasureName()
 
+        # Ruby allows **not** passing model to the method, so test that
+        arguments = measure.arguments()
+        assert arguments.size() == 1
+        assert arguments[0].name() == 'space_name'
 
-  def test_good_argument_values(self):
-    # create an instance of the measure
-    measure = PythonMeasureName()
+    def test_good_argument_values(self):
+        """
+        Test running the measure with appropriate arguments, and that the
+        measure runs fine and with expected results
+        """
 
-    # create runner with empty OSW
-    osw = openstudio.WorkflowJSON()
-    runner = openstudio.measure.OSRunner(osw)
+        # create an instance of the measure
+        measure = PythonMeasureName()
 
-    # load the test model
-    # translator = openstudio.osversion.VersionTranslator()
-    # path = pathlib.Path(__file__).parent.absolute() / "examle_model.osm"
-    # model = translator.loadModel(path)
-    # assert(model.is_initialized())
-    # model = model.get()
+        # create runner with empty OSW
+        osw = openstudio.WorkflowJSON()
+        runner = openstudio.measure.OSRunner(osw)
 
-    model = openstudio.model.Model()
+        # load the test model
+        # translator = openstudio.osversion.VersionTranslator()
+        # path = openstudio.toPath(
+        #     str(pathlib.Path(__file__).parent.absolute()
+        #         / "examle_model.osm"))
+        # model = translator.loadModel(path)
+        # assert(model.is_initialized())
+        # model = model.get()
 
-    # store the number of spaces in the seed model
-    num_spaces_seed = len(model.getSpaces())
+        model = openstudio.model.Model()
 
-    # get arguments
-    arguments = measure.arguments(model)
-    argument_map = openstudio.measure.convertOSArgumentVectorToMap(arguments)
+        # store the number of spaces in the seed model
+        num_spaces_seed = len(model.getSpaces())
 
-    # create hash of argument values.
-    # If the argument has a default that you want to use, you don't need it in the hash
-    args_dict = {}
-    args_dict['space_name'] = 'New Space'
-    # using defaults values from measure.rb for other arguments
+        # get arguments
+        arguments = measure.arguments(model)
+        argument_map = openstudio.measure.convertOSArgumentVectorToMap(arguments)
 
-    # populate argument with specified hash value if specified
-    for arg in arguments:
-        temp_arg_var = arg.clone()
-        if arg.name() in args_dict:
-            assert(temp_arg_var.setValue(args_dict[arg.name()]))
-        argument_map[arg.name()] = temp_arg_var
+        # create hash of argument values.
+        # If the argument has a default that you want to use,
+        # you don't need it in the dict
+        args_dict = {}
+        args_dict['space_name'] = 'New Space'
+        # using defaults values from measure.py for other arguments
 
-    print("run measure:")
+        # populate argument with specified hash value if specified
+        for arg in arguments:
+            temp_arg_var = arg.clone()
+            if arg.name() in args_dict:
+                assert(temp_arg_var.setValue(args_dict[arg.name()]))
+                argument_map[arg.name()] = temp_arg_var
 
-    # run the measure
-    measure.run(model, runner, argument_map)
-    result = runner.result()
+        print("run measure:")
 
-    # show the output
-    # show_output(result)
-    print(f"results: {result}")
+        # run the measure
+        measure.run(model, runner, argument_map)
+        result = runner.result()
 
-    # assert that it ran correctly
-    assert result.value().valueName() == 'Success'
-    assert len(result.info()) == 1
-    assert len(result.warnings()) == 0
+        num_spaces_final = len(model.getSpaces())
 
-    assert result.info()[0].logMessage() == "Space New Space was added."
+        # show the output
+        # show_output(result)
+        print(f"results: {result}")
 
-    # save the model to test output directory
-    #output_file_path = "#{File.dirname(__FILE__)}//output/test_output.osm"
-    #model.save(output_file_path, true)
+        # assert that it ran correctly
+        assert result.value().valueName() == 'Success'
+        assert len(result.info()) == 1
+        assert len(result.warnings()) == 0
+
+        assert result.info()[0].logMessage() == "Space New Space was added."
+
+        assert num_spaces_final == num_spaces_seed + 1
+
+        # save the model to test output directory
+        output_file_path = openstudio.toPath(
+            str(pathlib.Path(__file__).parent.absolute()
+                / "output" / "test_output.osm"))
+        model.save(output_file_path, True)

--- a/spec/files/python_measure/measures/PythonMeasure/tests/test_model_measure.py
+++ b/spec/files/python_measure/measures/PythonMeasure/tests/test_model_measure.py
@@ -1,0 +1,84 @@
+# insert your copyright here
+
+import pytest
+import openstudio
+import pathlib
+from measure import PythonMeasureName
+
+class TestPythonMeasureName:
+  # def setup
+  # end
+
+  # def teardown
+  # end
+
+  def test_number_of_arguments_and_argument_names(self):
+    # create an instance of the measure
+    measure = PythonMeasureName()
+
+    # make an empty model
+    model = openstudio.model.Model()
+
+    # get arguments and test that they are what we are expecting
+    arguments = measure.arguments(model)
+    assert arguments.size() == 1
+    assert arguments[0].name() == 'space_name'
+
+
+  def test_good_argument_values(self):
+    # create an instance of the measure
+    measure = PythonMeasureName()
+
+    # create runner with empty OSW
+    osw = openstudio.WorkflowJSON()
+    runner = openstudio.measure.OSRunner(osw)
+
+    # load the test model
+    # translator = openstudio.osversion.VersionTranslator()
+    # path = pathlib.Path(__file__).parent.absolute() / "examle_model.osm"
+    # model = translator.loadModel(path)
+    # assert(model.is_initialized())
+    # model = model.get()
+
+    model = openstudio.model.Model()
+
+    # store the number of spaces in the seed model
+    num_spaces_seed = len(model.getSpaces())
+
+    # get arguments
+    arguments = measure.arguments(model)
+    argument_map = openstudio.measure.convertOSArgumentVectorToMap(arguments)
+
+    # create hash of argument values.
+    # If the argument has a default that you want to use, you don't need it in the hash
+    args_dict = {}
+    args_dict['space_name'] = 'New Space'
+    # using defaults values from measure.rb for other arguments
+
+    # populate argument with specified hash value if specified
+    for arg in arguments:
+        temp_arg_var = arg.clone()
+        if arg.name() in args_dict:
+            assert(temp_arg_var.setValue(args_dict[arg.name()]))
+        argument_map[arg.name()] = temp_arg_var
+
+    print("run measure:")
+
+    # run the measure
+    measure.run(model, runner, argument_map)
+    result = runner.result()
+
+    # show the output
+    # show_output(result)
+    print(f"results: {result}")
+
+    # assert that it ran correctly
+    assert result.value().valueName() == 'Success'
+    assert len(result.info()) == 1
+    assert len(result.warnings()) == 0
+
+    assert result.info()[0].logMessage() == "Space New Space was added."
+
+    # save the model to test output directory
+    #output_file_path = "#{File.dirname(__FILE__)}//output/test_output.osm"
+    #model.save(output_file_path, true)

--- a/spec/files/python_measure/python.osw
+++ b/spec/files/python_measure/python.osw
@@ -4,7 +4,9 @@
     "steps": [
         {
             "measure_dir_name": "PythonMeasure",
-            "arguments": {"space_name": "My New Space"},
+            "arguments": {
+                "space_name": "My New Space"
+            },
             "measure_type": "PythonMeasure"
         }
     ],

--- a/spec/files/python_measure/python.osw
+++ b/spec/files/python_measure/python.osw
@@ -1,18 +1,18 @@
 {
-	"weather_file": "srrl_2013_amy.epw",
-	"seed_file": null,
-	"steps": [
-		{
-  		   "measure_dir_name": "PythonMeasure",
-		   "arguments": {},
-		   "measure_type": "PythonMeasure"
-		}
-	],
-  "run_options": {
-    "preserve_run_dir": false,
-    "fast": true,
-    "skip_expand_objects": true,
-    "skip_energyplus_preprocess": true,
-    "cleanup": false
-  }
+    "weather_file": "srrl_2013_amy.epw",
+    "seed_file": null,
+    "steps": [
+        {
+            "measure_dir_name": "PythonMeasure",
+            "arguments": {"space_name": "My New Space"},
+            "measure_type": "PythonMeasure"
+        }
+    ],
+    "run_options": {
+        "preserve_run_dir": false,
+        "fast": true,
+        "skip_expand_objects": true,
+        "skip_energyplus_preprocess": true,
+        "cleanup": false
+    }
 }


### PR DESCRIPTION
```
$ cd OpenStudio-workflow-gem/spec/files/python_measure/measures/PythonMeasure

$ pytest

Test session starts (platform: linux, Python 3.8.3, pytest 6.2.1, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /home/julien/Software, configfile: setup.cfg
plugins: django-4.1.0, sugar-0.9.4, Faker-5.0.1
collecting ... 
 Others/openstudio_gems/OpenStudio-workflow-gem/spec/files/python_measure/measures/PythonMeasure/tests/test_model_measure.py::TestPythonMeasureName.test_number_of_arguments_and_argument_names ✓50% █████     
 Others/openstudio_gems/OpenStudio-workflow-gem/spec/files/python_measure/measures/PythonMeasure/tests/test_model_measure.py::TestPythonMeasureName.test_good_argument_values ✓              100% ██████████
--------------------------- generated xml file: /home/julien/Software/Others/openstudio_gems/OpenStudio-workflow-gem/spec/files/python_measure/measures/PythonMeasure/junit.xml ----------------------------

Results (0.80s):
       2 passed

```