### PR TITLE
Fix for openstudio issue 4150

### DIFF
--- a/lib/openstudio/workflow/util/measure.rb
+++ b/lib/openstudio/workflow/util/measure.rb
@@ -342,6 +342,8 @@ module OpenStudio
             result = nil
             begin
               load measure_path.to_s
+              # load.c in ruby can result in changing dir to root / so preserve cwd here. happens in openstudio cli 
+              Dir.chdir measure_run_dir 
               measure_object = Object.const_get(class_name).new
             rescue => e
 


### PR DESCRIPTION
This is fix for https://github.com/NREL/OpenStudio/issues/4150 

This seems to only happen when using the OpenStudio CL vs pure ruby. 

I think the issue is in load.c in ruby but not sure exactly where. When loading measure that has catches LoadError type,, the cwd is changed to root / and causes issues. We can simply maintain the cwd by changing dir after the  `load` call.  
```

 begin
   # try to load a non existent gem to force LoadError
   require "a-gem-that-does-not-exist"
 rescue LoadError
   puts "Failed to load. Keep moving" 
```