### PR TITLE
Adjust ForwardTranslatorOptions

### DIFF
--- a/lib/openstudio/workflow/adapters/input/local.rb
+++ b/lib/openstudio/workflow/adapters/input/local.rb
@@ -343,7 +343,7 @@ module OpenStudio
 
           # try to read from OSW
           if @run_options.is_initialized
-            jsonOpts = ""
+            ftOpts = ""
             if @run_options.get.respond_to?(:forwardTranslatorOptions)
               # 3.6.0 and above. It still defines forwardTranslateOptions for
               # backward compatibility but trying to avoid a Warn in the log


### PR DESCRIPTION
* Following https://github.com/NREL/OpenStudio/pull/4739
* I first started this PR just to ignore a warning, but I realized it was returning early: if the user passed any ft_options via the CLI, it wouldn't even try to read the WorkflowJSON ones, when really we want to merge them
* I could update the openstudio_cli.rb and this code to use the new ForwardTranslatorOptions class to set on the EnergyPlus::ForwardTranslator, but it'll take a bit of work and this is eventually going to be replaced via C++ anyways.