### PR TITLE
Allow more unique objects in reporting measure's `energyPlusOutputRequests()`

### DIFF
--- a/lib/openstudio/workflow/util/energyplus.rb
+++ b/lib/openstudio/workflow/util/energyplus.rb
@@ -325,6 +325,7 @@ module OpenStudio
           allowed_unique_objects << 'OutputControl:ReportingTolerances' # replace existing
           # allowed_unique_objects << 'OutputControl:SurfaceColorScheme' # not wrapped
           allowed_unique_objects << 'OutputControl:Table:Style' # replace existing
+          allowed_unique_objects << 'OutputControl:Timestamp' # replace existing
           allowed_unique_objects << 'Output:DebuggingData' # replace existing
           allowed_unique_objects << 'Output:Diagnostics' # replace existing
           allowed_unique_objects << 'Output:EnergyManagementSystem' # replace existing
@@ -332,7 +333,7 @@ module OpenStudio
           allowed_unique_objects << 'Output:JSON' # replace existing
           allowed_unique_objects << 'Output:Schedules' # replace existing
           allowed_unique_objects << 'Output:SQLite' # replace existing
-          allowed_unique_objects << 'Output:Table:SummaryReports' # have to merge
+          allowed_unique_objects << 'Output:Table:SummaryReports' # merge with existing
 
           if allowed_unique_objects.include?(idf_object.iddObject.name)
             existing_objects = workspace.getObjectsByType(idf_object.iddObject.type)

--- a/lib/openstudio/workflow/util/energyplus.rb
+++ b/lib/openstudio/workflow/util/energyplus.rb
@@ -330,9 +330,9 @@ module OpenStudio
           allowed_unique_objects << 'Output:Diagnostics' # replace existing
           allowed_unique_objects << 'Output:EnergyManagementSystem' # replace existing
           allowed_unique_objects << 'Output:EnvironmentalImpactFactors' # replace existing
-          allowed_unique_objects << 'Output:JSON' # replace existing
+          # allowed_unique_objects << 'Output:JSON' # TODO: add a merge function
           allowed_unique_objects << 'Output:Schedules' # replace existing
-          allowed_unique_objects << 'Output:SQLite' # replace existing
+          # allowed_unique_objects << 'Output:SQLite' # TODO: add a merge function
           allowed_unique_objects << 'Output:Table:SummaryReports' # merge with existing
 
           if allowed_unique_objects.include?(idf_object.iddObject.name)

--- a/lib/openstudio/workflow/util/measure.rb
+++ b/lib/openstudio/workflow/util/measure.rb
@@ -508,7 +508,7 @@ module OpenStudio
                   idf_objects = measure_object.energyPlusOutputRequests(runner, argument_map)
                   num_added = 0
                   idf_objects.each do |idf_object|
-                    num_added += OpenStudio::Workflow::Util::EnergyPlus.add_energyplus_output_request(@model_idf, idf_object)
+                    num_added += OpenStudio::Workflow::Util::EnergyPlus.add_energyplus_output_request(@model_idf, idf_object, logger)
                   end
                   logger.debug "Finished measure.energyPlusOutputRequests for '#{measure_dir_name}', #{num_added} output requests added"
                 else


### PR DESCRIPTION
I wanted to set the new `OutputControl:Timestamp` object in a report measure but couldn't. This PR allows this object (and many other unique output objects) to be set. If the unique object already exists in the model, it's replaced and a warning is issued.

This would need to be ported to the C++ workflow [here](https://github.com/NREL/OpenStudio/blob/64d5ff2e1d5250dd9563d669de71fe1aa4609c84/src/workflow/Util.cpp#L162-L219) as well.