### PR TITLE
Fix #5101 - Update monthly reports for DistrictHeatingWater

### DIFF
--- a/lib/openstudio/workflow/jobs/resources/monthly_report.idf
+++ b/lib/openstudio/workflow/jobs/resources/monthly_report.idf
@@ -1,224 +1,223 @@
 Version,9.4;
 
 Output:Table:Monthly,
-  Building Energy Performance - Electricity,  !- Name
-    2,                       !- Digits After Decimal
-    InteriorLights:Electricity,  !- Variable or Meter 1 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 1
-    ExteriorLights:Electricity,  !- Variable or Meter 2 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 2
-    InteriorEquipment:Electricity,  !- Variable or Meter 3 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 3
-    ExteriorEquipment:Electricity,  !- Variable or Meter 4 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 4
-    Fans:Electricity,        !- Variable or Meter 5 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 5
-    Pumps:Electricity,       !- Variable or Meter 6 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 6
-    Heating:Electricity,     !- Variable or Meter 7 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 7
-    Cooling:Electricity,     !- Variable or Meter 8 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 8
-    HeatRejection:Electricity,  !- Variable or Meter 9 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 9
-    Humidifier:Electricity,  !- Variable or Meter 10 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 10
-    HeatRecovery:Electricity,!- Variable or Meter 11 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 11
-    WaterSystems:Electricity,!- Variable or Meter 12 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 12
-    Cogeneration:Electricity,!- Variable or Meter 13 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 13
-    Refrigeration:Electricity,!- Variable or Meter 14 Name
-    SumOrAverage;            !- Aggregation Type for Variable or Meter 14
+  Building Energy Performance - Electricity, !- Name
+  2,                                      !- Digits After Decimal
+  InteriorLights:Electricity,             !- Variable or Meter Name 1
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+  ExteriorLights:Electricity,             !- Variable or Meter Name 2
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+  InteriorEquipment:Electricity,          !- Variable or Meter Name 3
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+  ExteriorEquipment:Electricity,          !- Variable or Meter Name 4
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+  Fans:Electricity,                       !- Variable or Meter Name 5
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+  Pumps:Electricity,                      !- Variable or Meter Name 6
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
+  Heating:Electricity,                    !- Variable or Meter Name 7
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
+  Cooling:Electricity,                    !- Variable or Meter Name 8
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
+  HeatRejection:Electricity,              !- Variable or Meter Name 9
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
+  Humidifier:Electricity,                 !- Variable or Meter Name 10
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
+  HeatRecovery:Electricity,               !- Variable or Meter Name 11
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
+  WaterSystems:Electricity,               !- Variable or Meter Name 12
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
+  Cogeneration:Electricity,               !- Variable or Meter Name 13
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 13
+  Refrigeration:Electricity,              !- Variable or Meter Name 14
+  SumOrAverage;                           !- Aggregation Type for Variable or Meter 14
 
 Output:Table:Monthly,
-  Building Energy Performance - Natural Gas,  !- Name
-    2,                       !- Digits After Decimal
-    InteriorEquipment:NaturalGas,   !- Variable or Meter 1 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 1
-    ExteriorEquipment:NaturalGas,   !- Variable or Meter 2 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 2
-    Heating:NaturalGas,             !- Variable or Meter 3 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 3
-    Cooling:NaturalGas,             !- Variable or Meter 4 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 4
-    WaterSystems:NaturalGas,        !- Variable or Meter 5 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 5
-    Cogeneration:NaturalGas,        !- Variable or Meter 6 Name
-    SumOrAverage;            !- Aggregation Type for Variable or Meter 6
+  Building Energy Performance - Natural Gas, !- Name
+  2,                                      !- Digits After Decimal
+  InteriorEquipment:NaturalGas,           !- Variable or Meter Name 1
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+  ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+  Heating:NaturalGas,                     !- Variable or Meter Name 3
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+  Cooling:NaturalGas,                     !- Variable or Meter Name 4
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+  WaterSystems:NaturalGas,                !- Variable or Meter Name 5
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+  Cogeneration:NaturalGas,                !- Variable or Meter Name 6
+  SumOrAverage;                           !- Aggregation Type for Variable or Meter 6
 
 Output:Table:Monthly,
-  Building Energy Performance - District Heating,  !- Name
-    2,                       !- Digits After Decimal
-    InteriorLights:DistrictHeating,  !- Variable or Meter 1 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 1
-    ExteriorLights:DistrictHeating,  !- Variable or Meter 2 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 2
-    InteriorEquipment:DistrictHeating,  !- Variable or Meter 3 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 3
-    ExteriorEquipment:DistrictHeating,  !- Variable or Meter 4 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 4
-    Fans:DistrictHeating,        !- Variable or Meter 5 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 5
-    Pumps:DistrictHeating,       !- Variable or Meter 6 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 6
-    Heating:DistrictHeating,     !- Variable or Meter 7 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 7
-    Cooling:DistrictHeating,     !- Variable or Meter 8 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 8
-    HeatRejection:DistrictHeating,  !- Variable or Meter 9 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 9
-    Humidifier:DistrictHeating,  !- Variable or Meter 10 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 10
-    HeatRecovery:DistrictHeating,!- Variable or Meter 11 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 11
-    WaterSystems:DistrictHeating,!- Variable or Meter 12 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 12
-    Cogeneration:DistrictHeating,!- Variable or Meter 13 Name
-    SumOrAverage;            !- Aggregation Type for Variable or Meter 13
+  Building Energy Performance - District Heating, !- Name
+  2,                                      !- Digits After Decimal
+  InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+  Fans:DistrictHeating,                   !- Variable or Meter Name 5
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+  Pumps:DistrictHeating,                  !- Variable or Meter Name 6
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
+  Heating:DistrictHeating,                !- Variable or Meter Name 7
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
+  Cooling:DistrictHeating,                !- Variable or Meter Name 8
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
+  HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
+  Humidifier:DistrictHeating,             !- Variable or Meter Name 10
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
+  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
+  WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
+  Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
+  SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
 
 Output:Table:Monthly,
-  Building Energy Performance - District Cooling,  !- Name
-    2,                       !- Digits After Decimal
-    InteriorLights:DistrictCooling,  !- Variable or Meter 1 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 1
-    ExteriorLights:DistrictCooling,  !- Variable or Meter 2 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 2
-    InteriorEquipment:DistrictCooling,  !- Variable or Meter 3 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 3
-    ExteriorEquipment:DistrictCooling,  !- Variable or Meter 4 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 4
-    Fans:DistrictCooling,        !- Variable or Meter 5 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 5
-    Pumps:DistrictCooling,       !- Variable or Meter 6 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 6
-    Heating:DistrictCooling,     !- Variable or Meter 7 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 7
-    Cooling:DistrictCooling,     !- Variable or Meter 8 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 8
-    HeatRejection:DistrictCooling,  !- Variable or Meter 9 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 9
-    Humidifier:DistrictCooling,  !- Variable or Meter 10 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 10
-    HeatRecovery:DistrictCooling,!- Variable or Meter 11 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 11
-    WaterSystems:DistrictCooling,!- Variable or Meter 12 Name
-    SumOrAverage,            !- Aggregation Type for Variable or Meter 12
-    Cogeneration:DistrictCooling,!- Variable or Meter 13 Name
-    SumOrAverage;            !- Aggregation Type for Variable or Meter 13
+  Building Energy Performance - District Cooling, !- Name
+  2,                                      !- Digits After Decimal
+  InteriorLights:DistrictCooling,         !- Variable or Meter Name 1
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+  ExteriorLights:DistrictCooling,         !- Variable or Meter Name 2
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+  InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 3
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+  ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+  Fans:DistrictCooling,                   !- Variable or Meter Name 5
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+  Pumps:DistrictCooling,                  !- Variable or Meter Name 6
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
+  Heating:DistrictCooling,                !- Variable or Meter Name 7
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
+  Cooling:DistrictCooling,                !- Variable or Meter Name 8
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
+  HeatRejection:DistrictCooling,          !- Variable or Meter Name 9
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
+  Humidifier:DistrictCooling,             !- Variable or Meter Name 10
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
+  HeatRecovery:DistrictCooling,           !- Variable or Meter Name 11
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
+  WaterSystems:DistrictCooling,           !- Variable or Meter Name 12
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
+  Cogeneration:DistrictCooling,           !- Variable or Meter Name 13
+  SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
 
 Output:Table:Monthly,
-  Building Energy Performance - Electricity Peak Demand,  !- Name
-    2,                       !- Digits After Decimal
-    Electricity:Facility,  !- Variable or Meter 1 Name
-    Maximum,            !- Aggregation Type for Variable or Meter 1
-    InteriorLights:Electricity,  !- Variable or Meter 1 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 1
-    ExteriorLights:Electricity,  !- Variable or Meter 2 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 2
-    InteriorEquipment:Electricity,  !- Variable or Meter 3 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 3
-    ExteriorEquipment:Electricity,  !- Variable or Meter 4 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 4
-    Fans:Electricity,        !- Variable or Meter 5 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 5
-    Pumps:Electricity,       !- Variable or Meter 6 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 6
-    Heating:Electricity,     !- Variable or Meter 7 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 7
-    Cooling:Electricity,     !- Variable or Meter 8 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 8
-    HeatRejection:Electricity,  !- Variable or Meter 9 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 9
-    Humidifier:Electricity,  !- Variable or Meter 10 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 10
-    HeatRecovery:Electricity,!- Variable or Meter 11 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 11
-    WaterSystems:Electricity,!- Variable or Meter 12 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 12
-    Cogeneration:Electricity,!- Variable or Meter 13 Name
-    ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 13
+  Building Energy Performance - Electricity Peak Demand, !- Name
+  2,                                      !- Digits After Decimal
+  Electricity:Facility,                   !- Variable or Meter Name 1
+  Maximum,                                !- Aggregation Type for Variable or Meter 1
+  InteriorLights:Electricity,             !- Variable or Meter Name 1
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
+  ExteriorLights:Electricity,             !- Variable or Meter Name 2
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+  InteriorEquipment:Electricity,          !- Variable or Meter Name 3
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+  ExteriorEquipment:Electricity,          !- Variable or Meter Name 4
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+  Fans:Electricity,                       !- Variable or Meter Name 5
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+  Pumps:Electricity,                      !- Variable or Meter Name 6
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+  Heating:Electricity,                    !- Variable or Meter Name 7
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
+  Cooling:Electricity,                    !- Variable or Meter Name 8
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
+  HeatRejection:Electricity,              !- Variable or Meter Name 9
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
+  Humidifier:Electricity,                 !- Variable or Meter Name 10
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
+  HeatRecovery:Electricity,               !- Variable or Meter Name 11
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
+  WaterSystems:Electricity,               !- Variable or Meter Name 12
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
+  Cogeneration:Electricity,               !- Variable or Meter Name 13
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
 
 Output:Table:Monthly,
-  Building Energy Performance - Natural Gas Peak Demand,  !- Name
-    2,                       !- Digits After Decimal
-    NaturalGas:Facility,  !- Variable or Meter 1 Name
-    Maximum,            !- Aggregation Type for Variable or Meter 1
-    InteriorEquipment:NaturalGas,   !- Variable or Meter 1 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 1
-    ExteriorEquipment:NaturalGas,   !- Variable or Meter 2 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 2
-    Heating:NaturalGas,             !- Variable or Meter 3 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 3
-    Cooling:NaturalGas,             !- Variable or Meter 4 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 4
-    WaterSystems:NaturalGas,        !- Variable or Meter 5 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 5
-    Cogeneration:NaturalGas,        !- Variable or Meter 6 Name
-    ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 6
+  Building Energy Performance - Natural Gas Peak Demand, !- Name
+  2,                                      !- Digits After Decimal
+  NaturalGas:Facility,                    !- Variable or Meter Name 1
+  Maximum,                                !- Aggregation Type for Variable or Meter 1
+  InteriorEquipment:NaturalGas,           !- Variable or Meter Name 1
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
+  ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+  Heating:NaturalGas,                     !- Variable or Meter Name 3
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+  Cooling:NaturalGas,                     !- Variable or Meter Name 4
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+  WaterSystems:NaturalGas,                !- Variable or Meter Name 5
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+  Cogeneration:NaturalGas,                !- Variable or Meter Name 6
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 6
 
 Output:Table:Monthly,
-  Building Energy Performance - District Heating Peak Demand,  !- Name
-    2,                       !- Digits After Decimal
-    DistrictHeating:Facility,  !- Variable or Meter 1 Name
-    Maximum,            !- Aggregation Type for Variable or Meter 1
-    InteriorLights:DistrictHeating,  !- Variable or Meter 1 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 1
-    ExteriorLights:DistrictHeating,  !- Variable or Meter 2 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 2
-    InteriorEquipment:DistrictHeating,  !- Variable or Meter 3 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 3
-    ExteriorEquipment:DistrictHeating,  !- Variable or Meter 4 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 4
-    Fans:DistrictHeating,        !- Variable or Meter 5 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 5
-    Pumps:DistrictHeating,       !- Variable or Meter 6 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 6
-    Heating:DistrictHeating,     !- Variable or Meter 7 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 7
-    Cooling:DistrictHeating,     !- Variable or Meter 8 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 8
-    HeatRejection:DistrictHeating,  !- Variable or Meter 9 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 9
-    Humidifier:DistrictHeating,  !- Variable or Meter 10 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 10
-    HeatRecovery:DistrictHeating,!- Variable or Meter 11 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 11
-    WaterSystems:DistrictHeating,!- Variable or Meter 12 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 12
-    Cogeneration:DistrictHeating,!- Variable or Meter 13 Name
-    ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 13
+  Building Energy Performance - District Heating Peak Demand, !- Name
+  2,                                      !- Digits After Decimal
+  DistrictHeating:Facility,               !- Variable or Meter Name 1
+  Maximum,                                !- Aggregation Type for Variable or Meter 1
+  InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
+  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+  Fans:DistrictHeating,                   !- Variable or Meter Name 5
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+  Pumps:DistrictHeating,                  !- Variable or Meter Name 6
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+  Heating:DistrictHeating,                !- Variable or Meter Name 7
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
+  Cooling:DistrictHeating,                !- Variable or Meter Name 8
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
+  HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
+  Humidifier:DistrictHeating,             !- Variable or Meter Name 10
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
+  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
+  WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
+  Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
 
 Output:Table:Monthly,
-  Building Energy Performance - District Cooling Peak Demand,  !- Name
-    2,                       !- Digits After Decimal
-    DistrictCooling:Facility,  !- Variable or Meter 1 Name
-    Maximum,            !- Aggregation Type for Variable or Meter 1
-    InteriorLights:DistrictCooling,  !- Variable or Meter 1 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 1
-    ExteriorLights:DistrictCooling,  !- Variable or Meter 2 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 2
-    InteriorEquipment:DistrictCooling,  !- Variable or Meter 3 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 3
-    ExteriorEquipment:DistrictCooling,  !- Variable or Meter 4 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 4
-    Fans:DistrictCooling,        !- Variable or Meter 5 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 5
-    Pumps:DistrictCooling,       !- Variable or Meter 6 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 6
-    Heating:DistrictCooling,     !- Variable or Meter 7 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 7
-    Cooling:DistrictCooling,     !- Variable or Meter 8 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 8
-    HeatRejection:DistrictCooling,  !- Variable or Meter 9 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 9
-    Humidifier:DistrictCooling,  !- Variable or Meter 10 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 10
-    HeatRecovery:DistrictCooling,!- Variable or Meter 11 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 11
-    WaterSystems:DistrictCooling,!- Variable or Meter 12 Name
-    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 12
-    Cogeneration:DistrictCooling,!- Variable or Meter 13 Name
-    ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 13
-
+  Building Energy Performance - District Cooling Peak Demand, !- Name
+  2,                                      !- Digits After Decimal
+  DistrictCooling:Facility,               !- Variable or Meter Name 1
+  Maximum,                                !- Aggregation Type for Variable or Meter 1
+  InteriorLights:DistrictCooling,         !- Variable or Meter Name 1
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
+  ExteriorLights:DistrictCooling,         !- Variable or Meter Name 2
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+  InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 3
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+  ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+  Fans:DistrictCooling,                   !- Variable or Meter Name 5
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+  Pumps:DistrictCooling,                  !- Variable or Meter Name 6
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+  Heating:DistrictCooling,                !- Variable or Meter Name 7
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
+  Cooling:DistrictCooling,                !- Variable or Meter Name 8
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
+  HeatRejection:DistrictCooling,          !- Variable or Meter Name 9
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
+  Humidifier:DistrictCooling,             !- Variable or Meter Name 10
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
+  HeatRecovery:DistrictCooling,           !- Variable or Meter Name 11
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
+  WaterSystems:DistrictCooling,           !- Variable or Meter Name 12
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
+  Cogeneration:DistrictCooling,           !- Variable or Meter Name 13
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13

--- a/lib/openstudio/workflow/jobs/resources/monthly_report.idf
+++ b/lib/openstudio/workflow/jobs/resources/monthly_report.idf
@@ -1,4 +1,5 @@
-Version,9.4;
+Version,
+  23.2.0;                                 !- Version Identifier
 
 Output:Table:Monthly,
   Building Energy Performance - Electricity, !- Name
@@ -49,33 +50,33 @@ Output:Table:Monthly,
   SumOrAverage;                           !- Aggregation Type for Variable or Meter 6
 
 Output:Table:Monthly,
-  Building Energy Performance - District Heating, !- Name
+  Building Energy Performance - District Heating Water, !- Name
   2,                                      !- Digits After Decimal
-  InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
+  InteriorLights:DistrictHeatingWater,    !- Variable or Meter Name 1
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
-  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+  ExteriorLights:DistrictHeatingWater,    !- Variable or Meter Name 2
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
-  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
+  InteriorEquipment:DistrictHeatingWater, !- Variable or Meter Name 3
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
-  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+  ExteriorEquipment:DistrictHeatingWater, !- Variable or Meter Name 4
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
-  Fans:DistrictHeating,                   !- Variable or Meter Name 5
+  Fans:DistrictHeatingWater,              !- Variable or Meter Name 5
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
-  Pumps:DistrictHeating,                  !- Variable or Meter Name 6
+  Pumps:DistrictHeatingWater,             !- Variable or Meter Name 6
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
-  Heating:DistrictHeating,                !- Variable or Meter Name 7
+  Heating:DistrictHeatingWater,           !- Variable or Meter Name 7
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
-  Cooling:DistrictHeating,                !- Variable or Meter Name 8
+  Cooling:DistrictHeatingWater,           !- Variable or Meter Name 8
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
-  HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
+  HeatRejection:DistrictHeatingWater,     !- Variable or Meter Name 9
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
-  Humidifier:DistrictHeating,             !- Variable or Meter Name 10
+  Humidifier:DistrictHeatingWater,        !- Variable or Meter Name 10
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
-  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
+  HeatRecovery:DistrictHeatingWater,      !- Variable or Meter Name 11
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
-  WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
+  WaterSystems:DistrictHeatingWater,      !- Variable or Meter Name 12
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
-  Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
+  Cogeneration:DistrictHeatingWater,      !- Variable or Meter Name 13
   SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
 
 Output:Table:Monthly,
@@ -138,7 +139,9 @@ Output:Table:Monthly,
   WaterSystems:Electricity,               !- Variable or Meter Name 13
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
   Cogeneration:Electricity,               !- Variable or Meter Name 14
-  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 14
+  Refrigeration:Electricity,              !- Variable or Meter Name 15
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 15
 
 Output:Table:Monthly,
   Building Energy Performance - Natural Gas Peak Demand, !- Name
@@ -159,35 +162,35 @@ Output:Table:Monthly,
   ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 7
 
 Output:Table:Monthly,
-  Building Energy Performance - District Heating Peak Demand, !- Name
+  Building Energy Performance - District Heating Water Peak Demand, !- Name
   2,                                      !- Digits After Decimal
-  DistrictHeating:Facility,               !- Variable or Meter Name 1
+  DistrictHeatingWater:Facility,          !- Variable or Meter Name 1
   Maximum,                                !- Aggregation Type for Variable or Meter 1
-  InteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+  InteriorLights:DistrictHeatingWater,    !- Variable or Meter Name 2
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 3
+  ExteriorLights:DistrictHeatingWater,    !- Variable or Meter Name 3
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+  InteriorEquipment:DistrictHeatingWater, !- Variable or Meter Name 4
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 5
+  ExteriorEquipment:DistrictHeatingWater, !- Variable or Meter Name 5
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-  Fans:DistrictHeating,                   !- Variable or Meter Name 6
+  Fans:DistrictHeatingWater,              !- Variable or Meter Name 6
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
-  Pumps:DistrictHeating,                  !- Variable or Meter Name 7
+  Pumps:DistrictHeatingWater,             !- Variable or Meter Name 7
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
-  Heating:DistrictHeating,                !- Variable or Meter Name 8
+  Heating:DistrictHeatingWater,           !- Variable or Meter Name 8
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
-  Cooling:DistrictHeating,                !- Variable or Meter Name 9
+  Cooling:DistrictHeatingWater,           !- Variable or Meter Name 9
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
-  HeatRejection:DistrictHeating,          !- Variable or Meter Name 10
+  HeatRejection:DistrictHeatingWater,     !- Variable or Meter Name 10
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
-  Humidifier:DistrictHeating,             !- Variable or Meter Name 11
+  Humidifier:DistrictHeatingWater,        !- Variable or Meter Name 11
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
-  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 12
+  HeatRecovery:DistrictHeatingWater,      !- Variable or Meter Name 12
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
-  WaterSystems:DistrictHeating,           !- Variable or Meter Name 13
+  WaterSystems:DistrictHeatingWater,      !- Variable or Meter Name 13
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
-  Cogeneration:DistrictHeating,           !- Variable or Meter Name 14
+  Cogeneration:DistrictHeatingWater,      !- Variable or Meter Name 14
   ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
 
 Output:Table:Monthly,

--- a/lib/openstudio/workflow/jobs/resources/monthly_report.idf
+++ b/lib/openstudio/workflow/jobs/resources/monthly_report.idf
@@ -113,111 +113,111 @@ Output:Table:Monthly,
   2,                                      !- Digits After Decimal
   Electricity:Facility,                   !- Variable or Meter Name 1
   Maximum,                                !- Aggregation Type for Variable or Meter 1
-  InteriorLights:Electricity,             !- Variable or Meter Name 1
-  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
-  ExteriorLights:Electricity,             !- Variable or Meter Name 2
+  InteriorLights:Electricity,             !- Variable or Meter Name 2
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-  InteriorEquipment:Electricity,          !- Variable or Meter Name 3
+  ExteriorLights:Electricity,             !- Variable or Meter Name 3
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-  ExteriorEquipment:Electricity,          !- Variable or Meter Name 4
+  InteriorEquipment:Electricity,          !- Variable or Meter Name 4
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-  Fans:Electricity,                       !- Variable or Meter Name 5
+  ExteriorEquipment:Electricity,          !- Variable or Meter Name 5
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-  Pumps:Electricity,                      !- Variable or Meter Name 6
+  Fans:Electricity,                       !- Variable or Meter Name 6
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
-  Heating:Electricity,                    !- Variable or Meter Name 7
+  Pumps:Electricity,                      !- Variable or Meter Name 7
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
-  Cooling:Electricity,                    !- Variable or Meter Name 8
+  Heating:Electricity,                    !- Variable or Meter Name 8
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
-  HeatRejection:Electricity,              !- Variable or Meter Name 9
+  Cooling:Electricity,                    !- Variable or Meter Name 9
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
-  Humidifier:Electricity,                 !- Variable or Meter Name 10
+  HeatRejection:Electricity,              !- Variable or Meter Name 10
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
-  HeatRecovery:Electricity,               !- Variable or Meter Name 11
+  Humidifier:Electricity,                 !- Variable or Meter Name 11
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
-  WaterSystems:Electricity,               !- Variable or Meter Name 12
+  HeatRecovery:Electricity,               !- Variable or Meter Name 12
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
-  Cogeneration:Electricity,               !- Variable or Meter Name 13
-  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
+  WaterSystems:Electricity,               !- Variable or Meter Name 13
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
+  Cogeneration:Electricity,               !- Variable or Meter Name 14
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
 
 Output:Table:Monthly,
   Building Energy Performance - Natural Gas Peak Demand, !- Name
   2,                                      !- Digits After Decimal
   NaturalGas:Facility,                    !- Variable or Meter Name 1
   Maximum,                                !- Aggregation Type for Variable or Meter 1
-  InteriorEquipment:NaturalGas,           !- Variable or Meter Name 1
-  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
-  ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
+  InteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-  Heating:NaturalGas,                     !- Variable or Meter Name 3
+  ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 3
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-  Cooling:NaturalGas,                     !- Variable or Meter Name 4
+  Heating:NaturalGas,                     !- Variable or Meter Name 4
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-  WaterSystems:NaturalGas,                !- Variable or Meter Name 5
+  Cooling:NaturalGas,                     !- Variable or Meter Name 5
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-  Cogeneration:NaturalGas,                !- Variable or Meter Name 6
-  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 6
+  WaterSystems:NaturalGas,                !- Variable or Meter Name 6
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+  Cogeneration:NaturalGas,                !- Variable or Meter Name 7
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 7
 
 Output:Table:Monthly,
   Building Energy Performance - District Heating Peak Demand, !- Name
   2,                                      !- Digits After Decimal
   DistrictHeating:Facility,               !- Variable or Meter Name 1
   Maximum,                                !- Aggregation Type for Variable or Meter 1
-  InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
-  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
-  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+  InteriorLights:DistrictHeating,         !- Variable or Meter Name 2
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
+  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 3
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-  Fans:DistrictHeating,                   !- Variable or Meter Name 5
+  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 5
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-  Pumps:DistrictHeating,                  !- Variable or Meter Name 6
+  Fans:DistrictHeating,                   !- Variable or Meter Name 6
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
-  Heating:DistrictHeating,                !- Variable or Meter Name 7
+  Pumps:DistrictHeating,                  !- Variable or Meter Name 7
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
-  Cooling:DistrictHeating,                !- Variable or Meter Name 8
+  Heating:DistrictHeating,                !- Variable or Meter Name 8
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
-  HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
+  Cooling:DistrictHeating,                !- Variable or Meter Name 9
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
-  Humidifier:DistrictHeating,             !- Variable or Meter Name 10
+  HeatRejection:DistrictHeating,          !- Variable or Meter Name 10
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
-  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
+  Humidifier:DistrictHeating,             !- Variable or Meter Name 11
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
-  WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
+  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 12
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
-  Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
-  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
+  WaterSystems:DistrictHeating,           !- Variable or Meter Name 13
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
+  Cogeneration:DistrictHeating,           !- Variable or Meter Name 14
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
 
 Output:Table:Monthly,
   Building Energy Performance - District Cooling Peak Demand, !- Name
   2,                                      !- Digits After Decimal
   DistrictCooling:Facility,               !- Variable or Meter Name 1
   Maximum,                                !- Aggregation Type for Variable or Meter 1
-  InteriorLights:DistrictCooling,         !- Variable or Meter Name 1
-  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
-  ExteriorLights:DistrictCooling,         !- Variable or Meter Name 2
+  InteriorLights:DistrictCooling,         !- Variable or Meter Name 2
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-  InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 3
+  ExteriorLights:DistrictCooling,         !- Variable or Meter Name 3
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-  ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
+  InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-  Fans:DistrictCooling,                   !- Variable or Meter Name 5
+  ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 5
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-  Pumps:DistrictCooling,                  !- Variable or Meter Name 6
+  Fans:DistrictCooling,                   !- Variable or Meter Name 6
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
-  Heating:DistrictCooling,                !- Variable or Meter Name 7
+  Pumps:DistrictCooling,                  !- Variable or Meter Name 7
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
-  Cooling:DistrictCooling,                !- Variable or Meter Name 8
+  Heating:DistrictCooling,                !- Variable or Meter Name 8
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
-  HeatRejection:DistrictCooling,          !- Variable or Meter Name 9
+  Cooling:DistrictCooling,                !- Variable or Meter Name 9
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
-  Humidifier:DistrictCooling,             !- Variable or Meter Name 10
+  HeatRejection:DistrictCooling,          !- Variable or Meter Name 10
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
-  HeatRecovery:DistrictCooling,           !- Variable or Meter Name 11
+  Humidifier:DistrictCooling,             !- Variable or Meter Name 11
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
-  WaterSystems:DistrictCooling,           !- Variable or Meter Name 12
+  HeatRecovery:DistrictCooling,           !- Variable or Meter Name 12
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
-  Cogeneration:DistrictCooling,           !- Variable or Meter Name 13
-  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
+  WaterSystems:DistrictCooling,           !- Variable or Meter Name 13
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
+  Cogeneration:DistrictCooling,           !- Variable or Meter Name 14
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14

--- a/lib/openstudio/workflow/util/energyplus.rb
+++ b/lib/openstudio/workflow/util/energyplus.rb
@@ -351,227 +351,227 @@ module OpenStudio
 
         def self.monthly_report_idf_text
           <<~HEREDOC
-            Output:Table:Monthly,
-              Building Energy Performance - Electricity, !- Name
-              2,                                      !- Digits After Decimal
-              InteriorLights:Electricity,             !- Variable or Meter Name 1
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
-              ExteriorLights:Electricity,             !- Variable or Meter Name 2
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
-              InteriorEquipment:Electricity,          !- Variable or Meter Name 3
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
-              ExteriorEquipment:Electricity,          !- Variable or Meter Name 4
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
-              Fans:Electricity,                       !- Variable or Meter Name 5
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
-              Pumps:Electricity,                      !- Variable or Meter Name 6
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
-              Heating:Electricity,                    !- Variable or Meter Name 7
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
-              Cooling:Electricity,                    !- Variable or Meter Name 8
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
-              HeatRejection:Electricity,              !- Variable or Meter Name 9
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
-              Humidifier:Electricity,                 !- Variable or Meter Name 10
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
-              HeatRecovery:Electricity,               !- Variable or Meter Name 11
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
-              WaterSystems:Electricity,               !- Variable or Meter Name 12
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
-              Cogeneration:Electricity,               !- Variable or Meter Name 13
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 13
-              Refrigeration:Electricity,              !- Variable or Meter Name 14
-              SumOrAverage;                           !- Aggregation Type for Variable or Meter 14
+Output:Table:Monthly,
+  Building Energy Performance - Electricity, !- Name
+  2,                                      !- Digits After Decimal
+  InteriorLights:Electricity,             !- Variable or Meter Name 1
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+  ExteriorLights:Electricity,             !- Variable or Meter Name 2
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+  InteriorEquipment:Electricity,          !- Variable or Meter Name 3
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+  ExteriorEquipment:Electricity,          !- Variable or Meter Name 4
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+  Fans:Electricity,                       !- Variable or Meter Name 5
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+  Pumps:Electricity,                      !- Variable or Meter Name 6
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
+  Heating:Electricity,                    !- Variable or Meter Name 7
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
+  Cooling:Electricity,                    !- Variable or Meter Name 8
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
+  HeatRejection:Electricity,              !- Variable or Meter Name 9
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
+  Humidifier:Electricity,                 !- Variable or Meter Name 10
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
+  HeatRecovery:Electricity,               !- Variable or Meter Name 11
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
+  WaterSystems:Electricity,               !- Variable or Meter Name 12
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
+  Cogeneration:Electricity,               !- Variable or Meter Name 13
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 13
+  Refrigeration:Electricity,              !- Variable or Meter Name 14
+  SumOrAverage;                           !- Aggregation Type for Variable or Meter 14
 
-            Output:Table:Monthly,
-              Building Energy Performance - Natural Gas, !- Name
-              2,                                      !- Digits After Decimal
-              InteriorEquipment:NaturalGas,           !- Variable or Meter Name 1
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
-              ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
-              Heating:NaturalGas,                     !- Variable or Meter Name 3
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
-              Cooling:NaturalGas,                     !- Variable or Meter Name 4
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
-              WaterSystems:NaturalGas,                !- Variable or Meter Name 5
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
-              Cogeneration:NaturalGas,                !- Variable or Meter Name 6
-              SumOrAverage;                           !- Aggregation Type for Variable or Meter 6
+Output:Table:Monthly,
+  Building Energy Performance - Natural Gas, !- Name
+  2,                                      !- Digits After Decimal
+  InteriorEquipment:NaturalGas,           !- Variable or Meter Name 1
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+  ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+  Heating:NaturalGas,                     !- Variable or Meter Name 3
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+  Cooling:NaturalGas,                     !- Variable or Meter Name 4
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+  WaterSystems:NaturalGas,                !- Variable or Meter Name 5
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+  Cogeneration:NaturalGas,                !- Variable or Meter Name 6
+  SumOrAverage;                           !- Aggregation Type for Variable or Meter 6
 
-            Output:Table:Monthly,
-              Building Energy Performance - District Heating, !- Name
-              2,                                      !- Digits After Decimal
-              InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
-              ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
-              InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
-              ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
-              Fans:DistrictHeating,                   !- Variable or Meter Name 5
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
-              Pumps:DistrictHeating,                  !- Variable or Meter Name 6
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
-              Heating:DistrictHeating,                !- Variable or Meter Name 7
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
-              Cooling:DistrictHeating,                !- Variable or Meter Name 8
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
-              HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
-              Humidifier:DistrictHeating,             !- Variable or Meter Name 10
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
-              HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
-              WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
-              Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
-              SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
+Output:Table:Monthly,
+  Building Energy Performance - District Heating, !- Name
+  2,                                      !- Digits After Decimal
+  InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+  Fans:DistrictHeating,                   !- Variable or Meter Name 5
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+  Pumps:DistrictHeating,                  !- Variable or Meter Name 6
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
+  Heating:DistrictHeating,                !- Variable or Meter Name 7
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
+  Cooling:DistrictHeating,                !- Variable or Meter Name 8
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
+  HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
+  Humidifier:DistrictHeating,             !- Variable or Meter Name 10
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
+  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
+  WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
+  Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
+  SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
 
-            Output:Table:Monthly,
-              Building Energy Performance - District Cooling, !- Name
-              2,                                      !- Digits After Decimal
-              InteriorLights:DistrictCooling,         !- Variable or Meter Name 1
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
-              ExteriorLights:DistrictCooling,         !- Variable or Meter Name 2
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
-              InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 3
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
-              ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
-              Fans:DistrictCooling,                   !- Variable or Meter Name 5
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
-              Pumps:DistrictCooling,                  !- Variable or Meter Name 6
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
-              Heating:DistrictCooling,                !- Variable or Meter Name 7
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
-              Cooling:DistrictCooling,                !- Variable or Meter Name 8
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
-              HeatRejection:DistrictCooling,          !- Variable or Meter Name 9
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
-              Humidifier:DistrictCooling,             !- Variable or Meter Name 10
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
-              HeatRecovery:DistrictCooling,           !- Variable or Meter Name 11
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
-              WaterSystems:DistrictCooling,           !- Variable or Meter Name 12
-              SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
-              Cogeneration:DistrictCooling,           !- Variable or Meter Name 13
-              SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
+Output:Table:Monthly,
+  Building Energy Performance - District Cooling, !- Name
+  2,                                      !- Digits After Decimal
+  InteriorLights:DistrictCooling,         !- Variable or Meter Name 1
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+  ExteriorLights:DistrictCooling,         !- Variable or Meter Name 2
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+  InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 3
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+  ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+  Fans:DistrictCooling,                   !- Variable or Meter Name 5
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+  Pumps:DistrictCooling,                  !- Variable or Meter Name 6
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
+  Heating:DistrictCooling,                !- Variable or Meter Name 7
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
+  Cooling:DistrictCooling,                !- Variable or Meter Name 8
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
+  HeatRejection:DistrictCooling,          !- Variable or Meter Name 9
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
+  Humidifier:DistrictCooling,             !- Variable or Meter Name 10
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
+  HeatRecovery:DistrictCooling,           !- Variable or Meter Name 11
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
+  WaterSystems:DistrictCooling,           !- Variable or Meter Name 12
+  SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
+  Cogeneration:DistrictCooling,           !- Variable or Meter Name 13
+  SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
 
-            Output:Table:Monthly,
-              Building Energy Performance - Electricity Peak Demand, !- Name
-              2,                                      !- Digits After Decimal
-              Electricity:Facility,                   !- Variable or Meter Name 1
-              Maximum,                                !- Aggregation Type for Variable or Meter 1
-              InteriorLights:Electricity,             !- Variable or Meter Name 1
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
-              ExteriorLights:Electricity,             !- Variable or Meter Name 2
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-              InteriorEquipment:Electricity,          !- Variable or Meter Name 3
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-              ExteriorEquipment:Electricity,          !- Variable or Meter Name 4
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-              Fans:Electricity,                       !- Variable or Meter Name 5
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-              Pumps:Electricity,                      !- Variable or Meter Name 6
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
-              Heating:Electricity,                    !- Variable or Meter Name 7
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
-              Cooling:Electricity,                    !- Variable or Meter Name 8
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
-              HeatRejection:Electricity,              !- Variable or Meter Name 9
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
-              Humidifier:Electricity,                 !- Variable or Meter Name 10
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
-              HeatRecovery:Electricity,               !- Variable or Meter Name 11
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
-              WaterSystems:Electricity,               !- Variable or Meter Name 12
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
-              Cogeneration:Electricity,               !- Variable or Meter Name 13
-              ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
+Output:Table:Monthly,
+  Building Energy Performance - Electricity Peak Demand, !- Name
+  2,                                      !- Digits After Decimal
+  Electricity:Facility,                   !- Variable or Meter Name 1
+  Maximum,                                !- Aggregation Type for Variable or Meter 1
+  InteriorLights:Electricity,             !- Variable or Meter Name 2
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+  ExteriorLights:Electricity,             !- Variable or Meter Name 3
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+  InteriorEquipment:Electricity,          !- Variable or Meter Name 4
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+  ExteriorEquipment:Electricity,          !- Variable or Meter Name 5
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+  Fans:Electricity,                       !- Variable or Meter Name 6
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+  Pumps:Electricity,                      !- Variable or Meter Name 7
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
+  Heating:Electricity,                    !- Variable or Meter Name 8
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
+  Cooling:Electricity,                    !- Variable or Meter Name 9
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
+  HeatRejection:Electricity,              !- Variable or Meter Name 10
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
+  Humidifier:Electricity,                 !- Variable or Meter Name 11
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
+  HeatRecovery:Electricity,               !- Variable or Meter Name 12
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
+  WaterSystems:Electricity,               !- Variable or Meter Name 13
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
+  Cogeneration:Electricity,               !- Variable or Meter Name 14
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
 
-            Output:Table:Monthly,
-              Building Energy Performance - Natural Gas Peak Demand, !- Name
-              2,                                      !- Digits After Decimal
-              NaturalGas:Facility,                    !- Variable or Meter Name 1
-              Maximum,                                !- Aggregation Type for Variable or Meter 1
-              InteriorEquipment:NaturalGas,           !- Variable or Meter Name 1
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
-              ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-              Heating:NaturalGas,                     !- Variable or Meter Name 3
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-              Cooling:NaturalGas,                     !- Variable or Meter Name 4
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-              WaterSystems:NaturalGas,                !- Variable or Meter Name 5
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-              Cogeneration:NaturalGas,                !- Variable or Meter Name 6
-              ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 6
+Output:Table:Monthly,
+  Building Energy Performance - Natural Gas Peak Demand, !- Name
+  2,                                      !- Digits After Decimal
+  NaturalGas:Facility,                    !- Variable or Meter Name 1
+  Maximum,                                !- Aggregation Type for Variable or Meter 1
+  InteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+  ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 3
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+  Heating:NaturalGas,                     !- Variable or Meter Name 4
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+  Cooling:NaturalGas,                     !- Variable or Meter Name 5
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+  WaterSystems:NaturalGas,                !- Variable or Meter Name 6
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+  Cogeneration:NaturalGas,                !- Variable or Meter Name 7
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 7
 
-            Output:Table:Monthly,
-              Building Energy Performance - District Heating Peak Demand, !- Name
-              2,                                      !- Digits After Decimal
-              DistrictHeating:Facility,               !- Variable or Meter Name 1
-              Maximum,                                !- Aggregation Type for Variable or Meter 1
-              InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
-              ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-              InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-              ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-              Fans:DistrictHeating,                   !- Variable or Meter Name 5
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-              Pumps:DistrictHeating,                  !- Variable or Meter Name 6
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
-              Heating:DistrictHeating,                !- Variable or Meter Name 7
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
-              Cooling:DistrictHeating,                !- Variable or Meter Name 8
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
-              HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
-              Humidifier:DistrictHeating,             !- Variable or Meter Name 10
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
-              HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
-              WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
-              Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
-              ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
+Output:Table:Monthly,
+  Building Energy Performance - District Heating Peak Demand, !- Name
+  2,                                      !- Digits After Decimal
+  DistrictHeating:Facility,               !- Variable or Meter Name 1
+  Maximum,                                !- Aggregation Type for Variable or Meter 1
+  InteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 3
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 5
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+  Fans:DistrictHeating,                   !- Variable or Meter Name 6
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+  Pumps:DistrictHeating,                  !- Variable or Meter Name 7
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
+  Heating:DistrictHeating,                !- Variable or Meter Name 8
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
+  Cooling:DistrictHeating,                !- Variable or Meter Name 9
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
+  HeatRejection:DistrictHeating,          !- Variable or Meter Name 10
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
+  Humidifier:DistrictHeating,             !- Variable or Meter Name 11
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
+  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 12
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
+  WaterSystems:DistrictHeating,           !- Variable or Meter Name 13
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
+  Cogeneration:DistrictHeating,           !- Variable or Meter Name 14
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
 
-            Output:Table:Monthly,
-              Building Energy Performance - District Cooling Peak Demand, !- Name
-              2,                                      !- Digits After Decimal
-              DistrictCooling:Facility,               !- Variable or Meter Name 1
-              Maximum,                                !- Aggregation Type for Variable or Meter 1
-              InteriorLights:DistrictCooling,         !- Variable or Meter Name 1
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
-              ExteriorLights:DistrictCooling,         !- Variable or Meter Name 2
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-              InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 3
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-              ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-              Fans:DistrictCooling,                   !- Variable or Meter Name 5
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-              Pumps:DistrictCooling,                  !- Variable or Meter Name 6
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
-              Heating:DistrictCooling,                !- Variable or Meter Name 7
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
-              Cooling:DistrictCooling,                !- Variable or Meter Name 8
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
-              HeatRejection:DistrictCooling,          !- Variable or Meter Name 9
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
-              Humidifier:DistrictCooling,             !- Variable or Meter Name 10
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
-              HeatRecovery:DistrictCooling,           !- Variable or Meter Name 11
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
-              WaterSystems:DistrictCooling,           !- Variable or Meter Name 12
-              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
-              Cogeneration:DistrictCooling,           !- Variable or Meter Name 13
-              ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
+Output:Table:Monthly,
+  Building Energy Performance - District Cooling Peak Demand, !- Name
+  2,                                      !- Digits After Decimal
+  DistrictCooling:Facility,               !- Variable or Meter Name 1
+  Maximum,                                !- Aggregation Type for Variable or Meter 1
+  InteriorLights:DistrictCooling,         !- Variable or Meter Name 2
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+  ExteriorLights:DistrictCooling,         !- Variable or Meter Name 3
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+  InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+  ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 5
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+  Fans:DistrictCooling,                   !- Variable or Meter Name 6
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+  Pumps:DistrictCooling,                  !- Variable or Meter Name 7
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
+  Heating:DistrictCooling,                !- Variable or Meter Name 8
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
+  Cooling:DistrictCooling,                !- Variable or Meter Name 9
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
+  HeatRejection:DistrictCooling,          !- Variable or Meter Name 10
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
+  Humidifier:DistrictCooling,             !- Variable or Meter Name 11
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
+  HeatRecovery:DistrictCooling,           !- Variable or Meter Name 12
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
+  WaterSystems:DistrictCooling,           !- Variable or Meter Name 13
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
+  Cogeneration:DistrictCooling,           !- Variable or Meter Name 14
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
           HEREDOC
         end
       end

--- a/lib/openstudio/workflow/util/energyplus.rb
+++ b/lib/openstudio/workflow/util/energyplus.rb
@@ -352,226 +352,226 @@ module OpenStudio
         def self.monthly_report_idf_text
           <<~HEREDOC
             Output:Table:Monthly,
-              Building Energy Performance - Electricity,  !- Name
-                2,                       !- Digits After Decimal
-                InteriorLights:Electricity,  !- Variable or Meter 1 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 1
-                ExteriorLights:Electricity,  !- Variable or Meter 2 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 2
-                InteriorEquipment:Electricity,  !- Variable or Meter 3 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 3
-                ExteriorEquipment:Electricity,  !- Variable or Meter 4 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 4
-                Fans:Electricity,        !- Variable or Meter 5 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 5
-                Pumps:Electricity,       !- Variable or Meter 6 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 6
-                Heating:Electricity,     !- Variable or Meter 7 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 7
-                Cooling:Electricity,     !- Variable or Meter 8 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 8
-                HeatRejection:Electricity,  !- Variable or Meter 9 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 9
-                Humidifier:Electricity,  !- Variable or Meter 10 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 10
-                HeatRecovery:Electricity,!- Variable or Meter 11 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 11
-                WaterSystems:Electricity,!- Variable or Meter 12 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 12
-                Cogeneration:Electricity,!- Variable or Meter 13 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 13
-                Refrigeration:Electricity,!- Variable or Meter 14 Name
-                SumOrAverage;            !- Aggregation Type for Variable or Meter 14
+              Building Energy Performance - Electricity, !- Name
+              2,                                      !- Digits After Decimal
+              InteriorLights:Electricity,             !- Variable or Meter Name 1
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+              ExteriorLights:Electricity,             !- Variable or Meter Name 2
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+              InteriorEquipment:Electricity,          !- Variable or Meter Name 3
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+              ExteriorEquipment:Electricity,          !- Variable or Meter Name 4
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+              Fans:Electricity,                       !- Variable or Meter Name 5
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+              Pumps:Electricity,                      !- Variable or Meter Name 6
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
+              Heating:Electricity,                    !- Variable or Meter Name 7
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
+              Cooling:Electricity,                    !- Variable or Meter Name 8
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
+              HeatRejection:Electricity,              !- Variable or Meter Name 9
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
+              Humidifier:Electricity,                 !- Variable or Meter Name 10
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
+              HeatRecovery:Electricity,               !- Variable or Meter Name 11
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
+              WaterSystems:Electricity,               !- Variable or Meter Name 12
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
+              Cogeneration:Electricity,               !- Variable or Meter Name 13
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 13
+              Refrigeration:Electricity,              !- Variable or Meter Name 14
+              SumOrAverage;                           !- Aggregation Type for Variable or Meter 14
 
             Output:Table:Monthly,
-              Building Energy Performance - Natural Gas,  !- Name
-                2,                       !- Digits After Decimal
-                InteriorEquipment:NaturalGas,   !- Variable or Meter 1 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 1
-                ExteriorEquipment:NaturalGas,   !- Variable or Meter 2 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 2
-                Heating:NaturalGas,             !- Variable or Meter 3 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 3
-                Cooling:NaturalGas,             !- Variable or Meter 4 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 4
-                WaterSystems:NaturalGas,        !- Variable or Meter 5 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 5
-                Cogeneration:NaturalGas,        !- Variable or Meter 6 Name
-                SumOrAverage;            !- Aggregation Type for Variable or Meter 6
+              Building Energy Performance - Natural Gas, !- Name
+              2,                                      !- Digits After Decimal
+              InteriorEquipment:NaturalGas,           !- Variable or Meter Name 1
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+              ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+              Heating:NaturalGas,                     !- Variable or Meter Name 3
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+              Cooling:NaturalGas,                     !- Variable or Meter Name 4
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+              WaterSystems:NaturalGas,                !- Variable or Meter Name 5
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+              Cogeneration:NaturalGas,                !- Variable or Meter Name 6
+              SumOrAverage;                           !- Aggregation Type for Variable or Meter 6
 
             Output:Table:Monthly,
-              Building Energy Performance - District Heating,  !- Name
-                2,                       !- Digits After Decimal
-                InteriorLights:DistrictHeating,  !- Variable or Meter 1 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 1
-                ExteriorLights:DistrictHeating,  !- Variable or Meter 2 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 2
-                InteriorEquipment:DistrictHeating,  !- Variable or Meter 3 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 3
-                ExteriorEquipment:DistrictHeating,  !- Variable or Meter 4 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 4
-                Fans:DistrictHeating,        !- Variable or Meter 5 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 5
-                Pumps:DistrictHeating,       !- Variable or Meter 6 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 6
-                Heating:DistrictHeating,     !- Variable or Meter 7 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 7
-                Cooling:DistrictHeating,     !- Variable or Meter 8 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 8
-                HeatRejection:DistrictHeating,  !- Variable or Meter 9 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 9
-                Humidifier:DistrictHeating,  !- Variable or Meter 10 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 10
-                HeatRecovery:DistrictHeating,!- Variable or Meter 11 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 11
-                WaterSystems:DistrictHeating,!- Variable or Meter 12 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 12
-                Cogeneration:DistrictHeating,!- Variable or Meter 13 Name
-                SumOrAverage;            !- Aggregation Type for Variable or Meter 13
+              Building Energy Performance - District Heating, !- Name
+              2,                                      !- Digits After Decimal
+              InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+              ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+              InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+              ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+              Fans:DistrictHeating,                   !- Variable or Meter Name 5
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+              Pumps:DistrictHeating,                  !- Variable or Meter Name 6
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
+              Heating:DistrictHeating,                !- Variable or Meter Name 7
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
+              Cooling:DistrictHeating,                !- Variable or Meter Name 8
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
+              HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
+              Humidifier:DistrictHeating,             !- Variable or Meter Name 10
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
+              HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
+              WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
+              Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
+              SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
 
             Output:Table:Monthly,
-              Building Energy Performance - District Cooling,  !- Name
-                2,                       !- Digits After Decimal
-                InteriorLights:DistrictCooling,  !- Variable or Meter 1 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 1
-                ExteriorLights:DistrictCooling,  !- Variable or Meter 2 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 2
-                InteriorEquipment:DistrictCooling,  !- Variable or Meter 3 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 3
-                ExteriorEquipment:DistrictCooling,  !- Variable or Meter 4 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 4
-                Fans:DistrictCooling,        !- Variable or Meter 5 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 5
-                Pumps:DistrictCooling,       !- Variable or Meter 6 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 6
-                Heating:DistrictCooling,     !- Variable or Meter 7 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 7
-                Cooling:DistrictCooling,     !- Variable or Meter 8 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 8
-                HeatRejection:DistrictCooling,  !- Variable or Meter 9 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 9
-                Humidifier:DistrictCooling,  !- Variable or Meter 10 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 10
-                HeatRecovery:DistrictCooling,!- Variable or Meter 11 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 11
-                WaterSystems:DistrictCooling,!- Variable or Meter 12 Name
-                SumOrAverage,            !- Aggregation Type for Variable or Meter 12
-                Cogeneration:DistrictCooling,!- Variable or Meter 13 Name
-                SumOrAverage;            !- Aggregation Type for Variable or Meter 13
+              Building Energy Performance - District Cooling, !- Name
+              2,                                      !- Digits After Decimal
+              InteriorLights:DistrictCooling,         !- Variable or Meter Name 1
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
+              ExteriorLights:DistrictCooling,         !- Variable or Meter Name 2
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
+              InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 3
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
+              ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
+              Fans:DistrictCooling,                   !- Variable or Meter Name 5
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
+              Pumps:DistrictCooling,                  !- Variable or Meter Name 6
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
+              Heating:DistrictCooling,                !- Variable or Meter Name 7
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
+              Cooling:DistrictCooling,                !- Variable or Meter Name 8
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
+              HeatRejection:DistrictCooling,          !- Variable or Meter Name 9
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
+              Humidifier:DistrictCooling,             !- Variable or Meter Name 10
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
+              HeatRecovery:DistrictCooling,           !- Variable or Meter Name 11
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
+              WaterSystems:DistrictCooling,           !- Variable or Meter Name 12
+              SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
+              Cogeneration:DistrictCooling,           !- Variable or Meter Name 13
+              SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
 
             Output:Table:Monthly,
-              Building Energy Performance - Electricity Peak Demand,  !- Name
-                2,                       !- Digits After Decimal
-                Electricity:Facility,  !- Variable or Meter 1 Name
-                Maximum,            !- Aggregation Type for Variable or Meter 1
-                InteriorLights:Electricity,  !- Variable or Meter 1 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 1
-                ExteriorLights:Electricity,  !- Variable or Meter 2 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 2
-                InteriorEquipment:Electricity,  !- Variable or Meter 3 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 3
-                ExteriorEquipment:Electricity,  !- Variable or Meter 4 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 4
-                Fans:Electricity,        !- Variable or Meter 5 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 5
-                Pumps:Electricity,       !- Variable or Meter 6 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 6
-                Heating:Electricity,     !- Variable or Meter 7 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 7
-                Cooling:Electricity,     !- Variable or Meter 8 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 8
-                HeatRejection:Electricity,  !- Variable or Meter 9 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 9
-                Humidifier:Electricity,  !- Variable or Meter 10 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 10
-                HeatRecovery:Electricity,!- Variable or Meter 11 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 11
-                WaterSystems:Electricity,!- Variable or Meter 12 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 12
-                Cogeneration:Electricity,!- Variable or Meter 13 Name
-                ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 13
+              Building Energy Performance - Electricity Peak Demand, !- Name
+              2,                                      !- Digits After Decimal
+              Electricity:Facility,                   !- Variable or Meter Name 1
+              Maximum,                                !- Aggregation Type for Variable or Meter 1
+              InteriorLights:Electricity,             !- Variable or Meter Name 1
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
+              ExteriorLights:Electricity,             !- Variable or Meter Name 2
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+              InteriorEquipment:Electricity,          !- Variable or Meter Name 3
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+              ExteriorEquipment:Electricity,          !- Variable or Meter Name 4
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+              Fans:Electricity,                       !- Variable or Meter Name 5
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+              Pumps:Electricity,                      !- Variable or Meter Name 6
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+              Heating:Electricity,                    !- Variable or Meter Name 7
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
+              Cooling:Electricity,                    !- Variable or Meter Name 8
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
+              HeatRejection:Electricity,              !- Variable or Meter Name 9
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
+              Humidifier:Electricity,                 !- Variable or Meter Name 10
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
+              HeatRecovery:Electricity,               !- Variable or Meter Name 11
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
+              WaterSystems:Electricity,               !- Variable or Meter Name 12
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
+              Cogeneration:Electricity,               !- Variable or Meter Name 13
+              ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
 
             Output:Table:Monthly,
-              Building Energy Performance - Natural Gas Peak Demand,  !- Name
-                2,                       !- Digits After Decimal
-                NaturalGas:Facility,  !- Variable or Meter 1 Name
-                Maximum,            !- Aggregation Type for Variable or Meter 1
-                InteriorEquipment:NaturalGas,   !- Variable or Meter 1 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 1
-                ExteriorEquipment:NaturalGas,   !- Variable or Meter 2 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 2
-                Heating:NaturalGas,             !- Variable or Meter 3 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 3
-                Cooling:NaturalGas,             !- Variable or Meter 4 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 4
-                WaterSystems:NaturalGas,        !- Variable or Meter 5 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 5
-                Cogeneration:NaturalGas,        !- Variable or Meter 6 Name
-                ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 6
+              Building Energy Performance - Natural Gas Peak Demand, !- Name
+              2,                                      !- Digits After Decimal
+              NaturalGas:Facility,                    !- Variable or Meter Name 1
+              Maximum,                                !- Aggregation Type for Variable or Meter 1
+              InteriorEquipment:NaturalGas,           !- Variable or Meter Name 1
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
+              ExteriorEquipment:NaturalGas,           !- Variable or Meter Name 2
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+              Heating:NaturalGas,                     !- Variable or Meter Name 3
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+              Cooling:NaturalGas,                     !- Variable or Meter Name 4
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+              WaterSystems:NaturalGas,                !- Variable or Meter Name 5
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+              Cogeneration:NaturalGas,                !- Variable or Meter Name 6
+              ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 6
 
             Output:Table:Monthly,
-              Building Energy Performance - District Heating Peak Demand,  !- Name
-                2,                       !- Digits After Decimal
-                DistrictHeating:Facility,  !- Variable or Meter 1 Name
-                Maximum,            !- Aggregation Type for Variable or Meter 1
-                InteriorLights:DistrictHeating,  !- Variable or Meter 1 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 1
-                ExteriorLights:DistrictHeating,  !- Variable or Meter 2 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 2
-                InteriorEquipment:DistrictHeating,  !- Variable or Meter 3 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 3
-                ExteriorEquipment:DistrictHeating,  !- Variable or Meter 4 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 4
-                Fans:DistrictHeating,        !- Variable or Meter 5 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 5
-                Pumps:DistrictHeating,       !- Variable or Meter 6 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 6
-                Heating:DistrictHeating,     !- Variable or Meter 7 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 7
-                Cooling:DistrictHeating,     !- Variable or Meter 8 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 8
-                HeatRejection:DistrictHeating,  !- Variable or Meter 9 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 9
-                Humidifier:DistrictHeating,  !- Variable or Meter 10 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 10
-                HeatRecovery:DistrictHeating,!- Variable or Meter 11 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 11
-                WaterSystems:DistrictHeating,!- Variable or Meter 12 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 12
-                Cogeneration:DistrictHeating,!- Variable or Meter 13 Name
-                ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 13
+              Building Energy Performance - District Heating Peak Demand, !- Name
+              2,                                      !- Digits After Decimal
+              DistrictHeating:Facility,               !- Variable or Meter Name 1
+              Maximum,                                !- Aggregation Type for Variable or Meter 1
+              InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
+              ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+              InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+              ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+              Fans:DistrictHeating,                   !- Variable or Meter Name 5
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+              Pumps:DistrictHeating,                  !- Variable or Meter Name 6
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+              Heating:DistrictHeating,                !- Variable or Meter Name 7
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
+              Cooling:DistrictHeating,                !- Variable or Meter Name 8
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
+              HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
+              Humidifier:DistrictHeating,             !- Variable or Meter Name 10
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
+              HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
+              WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
+              Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
+              ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
 
             Output:Table:Monthly,
-              Building Energy Performance - District Cooling Peak Demand,  !- Name
-                2,                       !- Digits After Decimal
-                DistrictCooling:Facility,  !- Variable or Meter 1 Name
-                Maximum,            !- Aggregation Type for Variable or Meter 1
-                InteriorLights:DistrictCooling,  !- Variable or Meter 1 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 1
-                ExteriorLights:DistrictCooling,  !- Variable or Meter 2 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 2
-                InteriorEquipment:DistrictCooling,  !- Variable or Meter 3 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 3
-                ExteriorEquipment:DistrictCooling,  !- Variable or Meter 4 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 4
-                Fans:DistrictCooling,        !- Variable or Meter 5 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 5
-                Pumps:DistrictCooling,       !- Variable or Meter 6 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 6
-                Heating:DistrictCooling,     !- Variable or Meter 7 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 7
-                Cooling:DistrictCooling,     !- Variable or Meter 8 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 8
-                HeatRejection:DistrictCooling,  !- Variable or Meter 9 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 9
-                Humidifier:DistrictCooling,  !- Variable or Meter 10 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 10
-                HeatRecovery:DistrictCooling,!- Variable or Meter 11 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 11
-                WaterSystems:DistrictCooling,!- Variable or Meter 12 Name
-                ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 12
-                Cogeneration:DistrictCooling,!- Variable or Meter 13 Name
-                ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 13
+              Building Energy Performance - District Cooling Peak Demand, !- Name
+              2,                                      !- Digits After Decimal
+              DistrictCooling:Facility,               !- Variable or Meter Name 1
+              Maximum,                                !- Aggregation Type for Variable or Meter 1
+              InteriorLights:DistrictCooling,         !- Variable or Meter Name 1
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 1
+              ExteriorLights:DistrictCooling,         !- Variable or Meter Name 2
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
+              InteriorEquipment:DistrictCooling,      !- Variable or Meter Name 3
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
+              ExteriorEquipment:DistrictCooling,      !- Variable or Meter Name 4
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
+              Fans:DistrictCooling,                   !- Variable or Meter Name 5
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
+              Pumps:DistrictCooling,                  !- Variable or Meter Name 6
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
+              Heating:DistrictCooling,                !- Variable or Meter Name 7
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
+              Cooling:DistrictCooling,                !- Variable or Meter Name 8
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
+              HeatRejection:DistrictCooling,          !- Variable or Meter Name 9
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
+              Humidifier:DistrictCooling,             !- Variable or Meter Name 10
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
+              HeatRecovery:DistrictCooling,           !- Variable or Meter Name 11
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
+              WaterSystems:DistrictCooling,           !- Variable or Meter Name 12
+              ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
+              Cogeneration:DistrictCooling,           !- Variable or Meter Name 13
+              ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 13
           HEREDOC
         end
       end

--- a/lib/openstudio/workflow/util/energyplus.rb
+++ b/lib/openstudio/workflow/util/energyplus.rb
@@ -400,33 +400,33 @@ Output:Table:Monthly,
   SumOrAverage;                           !- Aggregation Type for Variable or Meter 6
 
 Output:Table:Monthly,
-  Building Energy Performance - District Heating, !- Name
+  Building Energy Performance - District Heating Water, !- Name
   2,                                      !- Digits After Decimal
-  InteriorLights:DistrictHeating,         !- Variable or Meter Name 1
+  InteriorLights:DistrictHeatingWater,    !- Variable or Meter Name 1
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 1
-  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+  ExteriorLights:DistrictHeatingWater,    !- Variable or Meter Name 2
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 2
-  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 3
+  InteriorEquipment:DistrictHeatingWater, !- Variable or Meter Name 3
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 3
-  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+  ExteriorEquipment:DistrictHeatingWater, !- Variable or Meter Name 4
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 4
-  Fans:DistrictHeating,                   !- Variable or Meter Name 5
+  Fans:DistrictHeatingWater,              !- Variable or Meter Name 5
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 5
-  Pumps:DistrictHeating,                  !- Variable or Meter Name 6
+  Pumps:DistrictHeatingWater,             !- Variable or Meter Name 6
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 6
-  Heating:DistrictHeating,                !- Variable or Meter Name 7
+  Heating:DistrictHeatingWater,           !- Variable or Meter Name 7
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 7
-  Cooling:DistrictHeating,                !- Variable or Meter Name 8
+  Cooling:DistrictHeatingWater,           !- Variable or Meter Name 8
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 8
-  HeatRejection:DistrictHeating,          !- Variable or Meter Name 9
+  HeatRejection:DistrictHeatingWater,     !- Variable or Meter Name 9
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 9
-  Humidifier:DistrictHeating,             !- Variable or Meter Name 10
+  Humidifier:DistrictHeatingWater,        !- Variable or Meter Name 10
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 10
-  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 11
+  HeatRecovery:DistrictHeatingWater,      !- Variable or Meter Name 11
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 11
-  WaterSystems:DistrictHeating,           !- Variable or Meter Name 12
+  WaterSystems:DistrictHeatingWater,      !- Variable or Meter Name 12
   SumOrAverage,                           !- Aggregation Type for Variable or Meter 12
-  Cogeneration:DistrictHeating,           !- Variable or Meter Name 13
+  Cogeneration:DistrictHeatingWater,      !- Variable or Meter Name 13
   SumOrAverage;                           !- Aggregation Type for Variable or Meter 13
 
 Output:Table:Monthly,
@@ -489,7 +489,9 @@ Output:Table:Monthly,
   WaterSystems:Electricity,               !- Variable or Meter Name 13
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
   Cogeneration:Electricity,               !- Variable or Meter Name 14
-  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
+  ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 14
+  Refrigeration:Electricity,              !- Variable or Meter Name 15
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 15
 
 Output:Table:Monthly,
   Building Energy Performance - Natural Gas Peak Demand, !- Name
@@ -510,35 +512,35 @@ Output:Table:Monthly,
   ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 7
 
 Output:Table:Monthly,
-  Building Energy Performance - District Heating Peak Demand, !- Name
+  Building Energy Performance - District Heating Water Peak Demand, !- Name
   2,                                      !- Digits After Decimal
-  DistrictHeating:Facility,               !- Variable or Meter Name 1
+  DistrictHeatingWater:Facility,          !- Variable or Meter Name 1
   Maximum,                                !- Aggregation Type for Variable or Meter 1
-  InteriorLights:DistrictHeating,         !- Variable or Meter Name 2
+  InteriorLights:DistrictHeatingWater,    !- Variable or Meter Name 2
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 2
-  ExteriorLights:DistrictHeating,         !- Variable or Meter Name 3
+  ExteriorLights:DistrictHeatingWater,    !- Variable or Meter Name 3
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 3
-  InteriorEquipment:DistrictHeating,      !- Variable or Meter Name 4
+  InteriorEquipment:DistrictHeatingWater, !- Variable or Meter Name 4
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 4
-  ExteriorEquipment:DistrictHeating,      !- Variable or Meter Name 5
+  ExteriorEquipment:DistrictHeatingWater, !- Variable or Meter Name 5
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 5
-  Fans:DistrictHeating,                   !- Variable or Meter Name 6
+  Fans:DistrictHeatingWater,              !- Variable or Meter Name 6
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 6
-  Pumps:DistrictHeating,                  !- Variable or Meter Name 7
+  Pumps:DistrictHeatingWater,             !- Variable or Meter Name 7
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 7
-  Heating:DistrictHeating,                !- Variable or Meter Name 8
+  Heating:DistrictHeatingWater,           !- Variable or Meter Name 8
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 8
-  Cooling:DistrictHeating,                !- Variable or Meter Name 9
+  Cooling:DistrictHeatingWater,           !- Variable or Meter Name 9
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 9
-  HeatRejection:DistrictHeating,          !- Variable or Meter Name 10
+  HeatRejection:DistrictHeatingWater,     !- Variable or Meter Name 10
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 10
-  Humidifier:DistrictHeating,             !- Variable or Meter Name 11
+  Humidifier:DistrictHeatingWater,        !- Variable or Meter Name 11
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 11
-  HeatRecovery:DistrictHeating,           !- Variable or Meter Name 12
+  HeatRecovery:DistrictHeatingWater,      !- Variable or Meter Name 12
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 12
-  WaterSystems:DistrictHeating,           !- Variable or Meter Name 13
+  WaterSystems:DistrictHeatingWater,      !- Variable or Meter Name 13
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
-  Cogeneration:DistrictHeating,           !- Variable or Meter Name 14
+  Cogeneration:DistrictHeatingWater,      !- Variable or Meter Name 14
   ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
 
 Output:Table:Monthly,
@@ -571,8 +573,7 @@ Output:Table:Monthly,
   WaterSystems:DistrictCooling,           !- Variable or Meter Name 13
   ValueWhenMaximumOrMinimum,              !- Aggregation Type for Variable or Meter 13
   Cogeneration:DistrictCooling,           !- Variable or Meter Name 14
-  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14
-          HEREDOC
+  ValueWhenMaximumOrMinimum;              !- Aggregation Type for Variable or Meter 14         HEREDOC
         end
       end
     end


### PR DESCRIPTION
* **Companion PR**:  https://github.com/NREL/OpenStudio/pull/5106

* Fix https://github.com/NREL/OpenStudio/issues/5101


* Note for the name of the Output:Table:Monthly: AFAIK, this is OpenStudio::EndUseFuelType::valueDescription that is used by reporting measures so I made the change as well, perhaps some of them harcoded it to "District Heating", I'm not sure
* `Electricity Peak Demand` was missing Refrigeration EUT

To see the actual changes to the Output:Table:Monthly, just look at https://github.com/NREL/OpenStudio-workflow-gem/pull/149/commits/32f37e2d00c103fd6d59d8573c7134d3ddf83b0a